### PR TITLE
small bugfix in systolic_array_tb

### DIFF
--- a/hwpq/systolic_array/rtl/sim/systolic_array_tb.sv
+++ b/hwpq/systolic_array/rtl/sim/systolic_array_tb.sv
@@ -156,7 +156,7 @@ module systolic_array_tb;
         i_read = 0;
         i_data = value;
         ref_queue.push_back(value);
-        ref_queue.sort() with (item > item);
+        ref_queue.rsort();
       end else begin
         $display("Enqueue: Queue full, skipping enqueue");
       end
@@ -174,7 +174,7 @@ module systolic_array_tb;
         i_wrt  = 0;
         i_read = 1;
         ref_queue.pop_front();
-        ref_queue.sort() with (item > item);
+        ref_queue.rsort();
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
@@ -193,7 +193,7 @@ module systolic_array_tb;
       i_data = value;
       ref_queue.pop_front();
       ref_queue.push_back(value);
-      ref_queue.sort() with (item > item);
+      ref_queue.rsort();
       @(posedge CLK);
       i_wrt  = 0;
       i_read = 0;


### PR DESCRIPTION
The testbench originally sorted the golden reference with `.sort() with (item > item)`, which did not properly sort the reference queue into a max queue, thus the systolic_array behavior was correct but the testbench was failing. Instead, using `.rsort()` places the elements of the reference queue in descending order, which properly reflects the behavior of our max queue systolic array. 