### PR TITLE
Fix/pr14 review comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ hwpq/register_array/rtl_elaboration/
 obj_dir
 *.vvp
 *.vcd
+
+build/

--- a/hwpq/bram_tree/rtl/sim/bram_tree_tb.sv
+++ b/hwpq/bram_tree/rtl/sim/bram_tree_tb.sv
@@ -45,6 +45,8 @@ module bram_tree_tb;
   // Clock generation: 10ns period
   always #5 CLK <= ~CLK;
 
+  int error_count = 0;
+
   initial begin
     // Initialize signals
     CLK = 0;
@@ -73,10 +75,10 @@ module bram_tree_tb;
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue[0])
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
         assert (o_data == '0)
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -90,7 +92,7 @@ module bram_tree_tb;
       random_value = $urandom_range(0, 1024);
       enqueue(random_value);
       assert (o_data == ref_queue[0])
-      else $error("Enqueue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+      else begin error_count++; $error("Enqueue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
     end
 
 
@@ -103,7 +105,7 @@ module bram_tree_tb;
       random_value = $urandom_range(0, 1024);
       replace(random_value);
       assert (o_data == ref_queue[0])
-      else $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+      else begin error_count++; $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
     end
 
     
@@ -118,7 +120,7 @@ module bram_tree_tb;
           enqueue(random_value);
           assert (o_data == ref_queue[0])
           else
-            $error("Enqueue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+            begin error_count++; $error("Enqueue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
         end
 
         DEQUEUE: begin
@@ -126,10 +128,10 @@ module bram_tree_tb;
           if (!o_empty) begin
             assert (o_data == ref_queue[0])
             else
-              $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+              begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
           end else begin
             assert (o_data == '0)
-            else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+            else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
 
@@ -137,7 +139,7 @@ module bram_tree_tb;
           replace(random_value);
           assert (o_data == ref_queue[0])
           else
-            $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+            begin error_count++; $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
         end
 
         default: begin
@@ -147,8 +149,13 @@ module bram_tree_tb;
     end
     
 
-    $display("\nTest completed! ");
-    $finish;
+    if (error_count == 0) begin
+      $display("\nTest completed!");
+      $finish;
+    end else begin
+      $display("\n%0d error(s) detected during simulation.", error_count);
+      $fatal(1, "Test FAILED with %0d error(s).", error_count);
+    end
   end
 
   // Task to write to the end of the queue

--- a/hwpq/bram_tree/rtl/src/bram_tree.sv
+++ b/hwpq/bram_tree/rtl/src/bram_tree.sv
@@ -1,7 +1,7 @@
 /*******************************************************************************
   Module Name: bram_tree
   Date: 2025/03/05
-  Description: A priority queue implementation using a binary min-heap structure
+  Description: A priority queue implementation using a binary max-heap structure
                stored in block RAM (BRAM). Supports enqueue, dequeue, and replace
                operations.
   Parameters: QUEUE_SIZE - Maximum number of elements in the priority queue
@@ -14,7 +14,6 @@
   Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
            o_empty - High when the queue is empty
            o_data - Output data from the highest priority element
-           o_ready - High if the tree is done propagating/rebalancing & ready for another read/write
 *******************************************************************************/
 
 package bram_tree_pkg;

--- a/hwpq/bram_tree/rtl/src/bram_tree.sv
+++ b/hwpq/bram_tree/rtl/src/bram_tree.sv
@@ -1,3 +1,22 @@
+/*******************************************************************************
+  Module Name: bram_tree
+  Date: 2025/03/05
+  Description: A priority queue implementation using a binary min-heap structure
+               stored in block RAM (BRAM). Supports enqueue, dequeue, and replace
+               operations.
+  Parameters: QUEUE_SIZE - Maximum number of elements in the priority queue
+              DATA_WIDTH - Bit width of data elements
+  Inputs: CLK - System clock
+          RSTn - Active-low reset signal
+          i_wrt - Write/insert command (enqueue operation)
+          i_read - Read/pop command (dequeue operation)
+          i_data - Input data to be enqueued
+  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
+           o_empty - High when the queue is empty
+           o_data - Output data from the highest priority element
+           o_ready - High if the tree is done propagating/rebalancing & ready for another read/write
+*******************************************************************************/
+
 package bram_tree_pkg;
   localparam integer DATA_WIDTH = 16;
   localparam integer QUEUE_SIZE = 7;

--- a/hwpq/bram_tree_pipelined/rtl/sim/pipelined_bram_tree_tb.sv
+++ b/hwpq/bram_tree_pipelined/rtl/sim/pipelined_bram_tree_tb.sv
@@ -50,6 +50,8 @@ module bram_tree_pipelined_tb;
   // Clock generation: 10ns period
   always #5 CLK <= ~CLK;
 
+  int error_count = 0;
+
   initial begin
     // Initialize signals
     CLK = 0;
@@ -81,10 +83,10 @@ module bram_tree_pipelined_tb;
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue[0])
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
         assert (o_data == '0)
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -109,7 +111,7 @@ module bram_tree_pipelined_tb;
       random_value = DataWidth'(($urandom & ((1 << DataWidth) - 1)) % 1025);
       replace(random_value);
       assert (o_data == ref_queue[0])
-      else $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+      else begin error_count++; $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
     end
 
     // Test Case 3: Stress Test
@@ -124,10 +126,10 @@ module bram_tree_pipelined_tb;
           if (!o_empty) begin
             assert (o_data == ref_queue[0])
             else
-              $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+              begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
           end else begin
             assert (o_data == '0)
-            else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+            else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
 
@@ -135,7 +137,7 @@ module bram_tree_pipelined_tb;
           replace(random_value);
           assert (o_data == ref_queue[0])
           else
-            $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+            begin error_count++; $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
         end
 
         default: begin
@@ -144,8 +146,13 @@ module bram_tree_pipelined_tb;
       endcase
     end
 
-    $display("\nTest completed! ");
-    $finish;
+    if (error_count == 0) begin
+      $display("\nTest completed!");
+      $finish;
+    end else begin
+      $display("\n%0d error(s) detected during simulation.", error_count);
+      $fatal(1, "Test FAILED with %0d error(s).", error_count);
+    end
   end
 
   // Task to read root node

--- a/hwpq/bram_tree_pipelined/rtl/src/bram_tree_pipelined.sv
+++ b/hwpq/bram_tree_pipelined/rtl/src/bram_tree_pipelined.sv
@@ -1,3 +1,24 @@
+/*******************************************************************************
+  Module Name: bram_tree_pipelined
+  Date: 2026/06/23
+  Description: A pipelined priority queue implementation using a binary max-heap
+               structure stored in block RAM, with the top few levels
+               kept in registers. Supports enqueue, dequeue, and replace
+               operations, trading throughput (one replace every four cycles)
+               for improved scalability over the non-pipelined BRAM tree.
+  Parameters: QUEUE_SIZE - Maximum number of elements in the priority queue
+              DATA_WIDTH - Bit width of data elements
+  Inputs: CLK - System clock
+          RSTn - Active-low reset signal
+          i_wrt - Write/insert command (enqueue operation)
+          i_read - Read/pop command (dequeue operation)
+          i_data - Input data to be inserted (or used for replace)
+  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
+           o_empty - High when the queue is empty
+           o_valid - High when o_data holds a valid output
+           o_data - Output data from the highest priority element
+*******************************************************************************/
+
 module bram_tree_pipelined #(
     parameter integer QUEUE_SIZE = 7,
     parameter integer DATA_WIDTH = 16

--- a/hwpq/bram_tree_pipelined/rtl/src/bram_tree_pipelined.sv
+++ b/hwpq/bram_tree_pipelined/rtl/src/bram_tree_pipelined.sv
@@ -15,7 +15,6 @@
           i_data - Input data to be inserted (or used for replace)
   Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
            o_empty - High when the queue is empty
-           o_valid - High when o_data holds a valid output
            o_data - Output data from the highest priority element
 *******************************************************************************/
 

--- a/hwpq/hybrid_tree/rtl/src/hybrid_tree.sv
+++ b/hwpq/hybrid_tree/rtl/src/hybrid_tree.sv
@@ -1,3 +1,24 @@
+/*******************************************************************************
+  Module Name: hybrid_tree
+  Date: 2025/03/21
+  Description: A hybrid priority queue (Max H-PQ) that combines a register
+               array holding the root nodes of multiple BRAM-based trees. New
+               items replace the leftmost register entry and propagate down
+               the corresponding BRAM tree, while the register array is kept
+               sorted so each entry is >= its right neighbor. Supports
+               enqueue, dequeue, and replace operations.
+  Parameters: QUEUE_SIZE - Maximum number of elements in the priority queue
+              DATA_WIDTH - Bit width of data elements
+  Inputs: CLK - System clock
+          RSTn - Active-low reset signal
+          i_wrt - Write/insert command (enqueue operation)
+          i_read - Read/pop command (dequeue operation)
+          i_data - Input data to be inserted (or used for replace)
+  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
+           o_empty - High when the queue is empty
+           o_data - Output data from the highest priority element
+*******************************************************************************/
+
 module hybrid_tree #(
     parameter integer QUEUE_SIZE = 4,
     parameter integer DATA_WIDTH = 16

--- a/hwpq/hybrid_tree/rtl/src/pipelined_bram_tree.sv
+++ b/hwpq/hybrid_tree/rtl/src/pipelined_bram_tree.sv
@@ -1,3 +1,24 @@
+/*******************************************************************************
+  Module Name: pipelined_bram_tree
+  Date: 2025/03/20
+  Description: A pipelined BRAM-based max-heap tree used as the sub-tree
+               building block of the hybrid_tree architecture. Levels beyond
+               the register-backed top are stored in block RAM, with an index
+               tracking the currently displaced node between levels. Supports
+               enqueue, dequeue, and replace operations.
+  Parameters: QUEUE_SIZE - Maximum number of elements in the sub-tree
+              DATA_WIDTH - Bit width of data elements
+  Inputs: CLK - System clock
+          RSTn - Active-low reset signal
+          i_wrt - Write/insert command (enqueue operation)
+          i_read - Read/pop command (dequeue operation)
+          i_data - Input data to be inserted (or used for replace)
+  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
+           o_empty - High when the queue is empty
+           o_valid - High when o_data holds a valid output
+           o_data - Output data from the highest priority element
+*******************************************************************************/
+
 module pipelined_bram_tree #(
     parameter integer QUEUE_SIZE = 7,
     parameter integer DATA_WIDTH = 16

--- a/hwpq/register_array/rtl/sim/register_array_tb.sv
+++ b/hwpq/register_array/rtl/sim/register_array_tb.sv
@@ -114,6 +114,8 @@ module register_array_tb;
   // Clock generation: 10ns period
   always #5 CLK <= ~CLK;
 
+  int error_count = 0;
+
   initial begin
     // Initialize signals
     CLK = 0;
@@ -144,16 +146,16 @@ module register_array_tb;
       random_value = $urandom_range(1, 1023);
       enqueue(random_value);
     end
-    assert (o_full) else $error("The queue should be filled by the intialization!");
+    assert (o_full) else begin error_count++; $error("The queue should be filled by the intialization!"); end;
 
     // Test Case 1: Dequeue nodes with ENQ_ENA enabled
     $display("\nTest Case 1: Dequeue Test (ENQ_ENA enabled)");
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
       if (!o_empty) begin
-        assert (o_data == ref_queue_enq_1[0]) else $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+        assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
       end else begin
-        assert (o_data == '0) else $error("Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+        assert (o_data == '0) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -162,16 +164,16 @@ module register_array_tb;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       random_value = $urandom_range(1, 1023);
       enqueue(random_value);
-      assert (o_data == ref_queue_enq_1[0]) else $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+      assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
-    assert (o_full) else $error("The queue should be filled after enqueue!");
+    assert (o_full) else begin error_count++; $error("The queue should be filled after enqueue!"); end;
 
     // Test Case 3: Replace nodes with ENQ_ENA enabled
     $display("\nTest Case 3: Replace Test (ENQ_ENA enabled)");
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       random_value = $urandom_range(1, 1023);
       replace(random_value);
-      assert (o_data == ref_queue_enq_1[0]) else $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+      assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
     
     // Test case 4: Random opertaion for 50 times
@@ -182,20 +184,20 @@ module register_array_tb;
         ENQUEUE: begin
           random_value = $urandom_range(1, 1023);
           enqueue(random_value);
-          assert (o_data == ref_queue_enq_1[0]) else $error("Random Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+          assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Random Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
         end
         DEQUEUE: begin
           dequeue();
           if (!o_empty) begin
-            assert (o_data == ref_queue_enq_1[0]) else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+            assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
           end else begin
-            assert (o_data == '0) else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+            assert (o_data == '0) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
         REPLACE: begin
           random_value = $urandom_range(1, 1023);
           replace(random_value);
-          assert (o_data == ref_queue_enq_1[0]) else $error("Random Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+          assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Random Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
         end
       endcase
     end
@@ -227,13 +229,13 @@ module register_array_tb;
 
     // Test Case 5: Dequeue Test with ENQ_ENA disabled
     $display("\nTest Case 5: Dequeue Test (ENQ_ENA disabled)");
-    assert (o_full) else $error("The queue should be filled by the intialization!");
+    assert (o_full) else begin error_count++; $error("The queue should be filled by the intialization!"); end;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
       if (!o_empty) begin
-        assert (o_data == ref_queue_enq_0[0]) else $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+        assert (o_data == ref_queue_enq_0[0]) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
       end else begin
-        assert (o_data == 'd0) else $error("Dequeue: Node value mismatch -> expected %d, got %d", 'd0, o_data);
+        assert (o_data == 'd0) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", 'd0, o_data); end;
       end
     end
     
@@ -244,9 +246,9 @@ module register_array_tb;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       random_value = $urandom_range(1, 1023);
       enqueue(random_value);
-      assert (o_data == ref_queue_enq_0[0]) else $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+      assert (o_data == ref_queue_enq_0[0]) else begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
     end
-    assert (o_data == o_data_prev) else $error("The queue should not have change!");
+    assert (o_data == o_data_prev) else begin error_count++; $error("The queue should not have change!"); end;
     begin
       bit queues_match;
       bit error_flag;
@@ -262,16 +264,16 @@ module register_array_tb;
           end
         end
       end
-      assert (!error_flag) else $error("The queue should not have change!");
+      assert (!error_flag) else begin error_count++; $error("The queue should not have change!"); end;
     end
-    assert (!o_full && !o_empty) else $error("The queue should not do anything!");
+    assert (!o_full && !o_empty) else begin error_count++; $error("The queue should not do anything!"); end;
 
     // Test Case 7: Test Replace operation with ENQ_ENA disabled
     $display("\nTest Case 7: Replace Test (ENQ_ENA disabled)");
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       random_value = $urandom_range(1, 1023);
       replace(random_value);
-      assert (o_data == ref_queue_enq_0[0]) else $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+      assert (o_data == ref_queue_enq_0[0]) else begin error_count++; $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
     end
     
     // Test case 8: Random opertaion for 50 times
@@ -282,21 +284,26 @@ module register_array_tb;
         DEQUEUE: begin
           dequeue();
           if (!o_empty) begin
-            assert (o_data == ref_queue_enq_0[0]) else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+            assert (o_data == ref_queue_enq_0[0]) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
           end else begin
-            assert (o_data == '0) else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+            assert (o_data == '0) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
         REPLACE: begin
           random_value = $urandom_range(1, 1023);
           replace(random_value);
-          assert (o_data == ref_queue_enq_0[0]) else $error("Random Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+          assert (o_data == ref_queue_enq_0[0]) else begin error_count++; $error("Random Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
         end
       endcase
     end
 
-    $display("\nTest completed!");
-    $finish;
+    if (error_count == 0) begin
+      $display("\nTest completed!");
+      $finish;
+    end else begin
+      $display("\n%0d error(s) detected during simulation.", error_count);
+      $fatal(1, "Test FAILED with %0d error(s).", error_count);
+    end
   end
 
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);

--- a/hwpq/register_array/rtl/sim/register_array_tb.sv
+++ b/hwpq/register_array/rtl/sim/register_array_tb.sv
@@ -309,21 +309,27 @@ module register_array_tb;
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     begin
       if (!o_full) begin
-        if (current_mode == ENABLED) begin
-          i_wrt_ena = 1;
-          i_read_ena = 0;
-          i_data_ena = value;
+        case (current_mode)
+          ENABLED: begin
+            i_wrt_ena = 1;
+            i_read_ena = 0;
+            i_data_ena = value;
 
-          ref_queue_enq_1[ref_queue_enq_1_size] = value;
-          ref_queue_enq_1_size++;
-      
-          rsort_ena();
-        end else if (current_mode == DISABLED) begin
-          i_wrt_dis = 1;
-          i_read_dis = 0;
-          i_data_dis = value;
-//          $display("Enqueue attempt with ENQ_ENA disabled - should have no effect");
-        end
+            ref_queue_enq_1[ref_queue_enq_1_size] = value;
+            ref_queue_enq_1_size++;
+
+            rsort_ena();
+          end
+          DISABLED: begin
+            i_wrt_dis = 1;
+            i_read_dis = 0;
+            i_data_dis = value;
+//            $display("Enqueue attempt with ENQ_ENA disabled - should have no effect");
+          end
+          default: begin
+            $display("Enqueue: Invalid mode, skipping enqueue");
+          end
+        endcase
       end else begin
         $display("Enqueue: Queue full, skipping enqueue");
       end
@@ -339,29 +345,33 @@ module register_array_tb;
   task automatic dequeue();
     begin
       if (!o_empty) begin
-        if (current_mode == ENABLED) begin
-          i_wrt_ena  = 0;
-          i_read_ena = 1;
-          i_data_ena = 0;
+        case (current_mode)
+          ENABLED: begin
+            i_wrt_ena  = 0;
+            i_read_ena = 1;
+            i_data_ena = 0;
 
-          for (int i = 0; i < ref_queue_enq_1_size - 1; i++) begin
-            ref_queue_enq_1[i] = ref_queue_enq_1[i+1];
+            for (int i = 0; i < ref_queue_enq_1_size - 1; i++) begin
+              ref_queue_enq_1[i] = ref_queue_enq_1[i+1];
+            end
+            ref_queue_enq_1[ref_queue_enq_1_size-1] = '0;
+            ref_queue_enq_1_size--;
           end
-          ref_queue_enq_1[ref_queue_enq_1_size-1] = '0; 
-          ref_queue_enq_1_size--;
+          DISABLED: begin
+            i_wrt_dis  = 0;
+            i_read_dis = 1;
+            i_data_dis = 0;
 
-        end else if (current_mode == DISABLED) begin
-          i_wrt_dis  = 0;
-          i_read_dis = 1;
-          i_data_dis = 0;
-
-          for (int i = 0; i < ref_queue_enq_0_size - 1; i++) begin
-            ref_queue_enq_0[i] = ref_queue_enq_0[i+1];
+            for (int i = 0; i < ref_queue_enq_0_size - 1; i++) begin
+              ref_queue_enq_0[i] = ref_queue_enq_0[i+1];
+            end
+            ref_queue_enq_0[ref_queue_enq_0_size-1] = '0;
+            ref_queue_enq_0_size--;
           end
-          ref_queue_enq_0[ref_queue_enq_0_size-1] = '0; 
-          ref_queue_enq_0_size--;
-
-        end
+          default: begin
+            $display("Dequeue: Invalid mode, skipping dequeue");
+          end
+        endcase
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
@@ -377,31 +387,37 @@ module register_array_tb;
 
   task automatic replace(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (current_mode == ENABLED) begin
-        i_wrt_ena  = 1;
-        i_read_ena = 1;
-        i_data_ena = value;
-        if (o_empty) begin
-          ref_queue_enq_1[ref_queue_enq_1_size] = value;
-          ref_queue_enq_1_size++;
-          rsort_ena();
-        end else begin
-          ref_queue_enq_1[0] = value;
-          rsort_ena();
+      case (current_mode)
+        ENABLED: begin
+          i_wrt_ena  = 1;
+          i_read_ena = 1;
+          i_data_ena = value;
+          if (o_empty) begin
+            ref_queue_enq_1[ref_queue_enq_1_size] = value;
+            ref_queue_enq_1_size++;
+            rsort_ena();
+          end else begin
+            ref_queue_enq_1[0] = value;
+            rsort_ena();
+          end
         end
-      end else if (current_mode == DISABLED) begin
-        i_wrt_dis  = 1;
-        i_read_dis = 1;
-        i_data_dis = value;
-        if (o_empty) begin
-          ref_queue_enq_0[ref_queue_enq_0_size] = value;
-          ref_queue_enq_0_size++;
-          rsort_dis();
-        end else begin
-          ref_queue_enq_0[0] = value;
-          rsort_dis();
+        DISABLED: begin
+          i_wrt_dis  = 1;
+          i_read_dis = 1;
+          i_data_dis = value;
+          if (o_empty) begin
+            ref_queue_enq_0[ref_queue_enq_0_size] = value;
+            ref_queue_enq_0_size++;
+            rsort_dis();
+          end else begin
+            ref_queue_enq_0[0] = value;
+            rsort_dis();
+          end
         end
-      end
+        default: begin
+          $display("Replace: Invalid mode, skipping replace");
+        end
+      endcase
       @(posedge CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
@@ -414,15 +430,21 @@ module register_array_tb;
 
   task automatic replace_init(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (current_mode == ENABLED) begin
-        i_wrt_ena  = 1;
-        i_read_ena = 1;
-        i_data_ena = value;
-      end else if (current_mode == DISABLED) begin
-        i_wrt_dis  = 1;
-        i_read_dis = 1;
-        i_data_dis = value;
-      end
+      case (current_mode)
+        ENABLED: begin
+          i_wrt_ena  = 1;
+          i_read_ena = 1;
+          i_data_ena = value;
+        end
+        DISABLED: begin
+          i_wrt_dis  = 1;
+          i_read_dis = 1;
+          i_data_dis = value;
+        end
+        default: begin
+          $display("Replace: Invalid mode, skipping replace");
+        end
+      endcase
       @(posedge CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;

--- a/hwpq/register_array/rtl/sim/register_array_tb.sv
+++ b/hwpq/register_array/rtl/sim/register_array_tb.sv
@@ -332,8 +332,7 @@ module register_array_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK); // should have no effects
+      repeat (2) @(posedge CLK);
     end
   endtask
 
@@ -371,8 +370,8 @@ module register_array_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+
+      repeat (2) @(posedge CLK);
     end
   endtask
 
@@ -408,8 +407,8 @@ module register_array_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+
+      repeat (2) @(posedge CLK);
     end
   endtask
 
@@ -429,8 +428,8 @@ module register_array_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+
+      repeat (2) @(posedge CLK);
     end
   endtask
 

--- a/hwpq/register_array/rtl/src/register_array.sv
+++ b/hwpq/register_array/rtl/src/register_array.sv
@@ -1,5 +1,26 @@
 `default_nettype none
 
+/*******************************************************************************
+  Module Name: register_array
+  Date: 2026/06/21
+  Description: A priority queue implementation that stores elements in a flat
+               register array rather than a hierarchical heap. A replace
+               operation overwrites the leftmost entry with the new item,
+               followed by two phases of array-wide compare-and-swap (even-
+               indexed then odd-indexed neighbor pairs) to restore order.
+  Parameters: ENQ_ENA - Enables the enqueue datapath when set
+              QUEUE_SIZE - Maximum number of elements in the priority queue
+              DATA_WIDTH - Bit width of data elements
+  Inputs: i_CLK - System clock
+          i_RSTn - Active-low reset signal
+          i_wrt - Write/insert command (enqueue/replace operation)
+          i_read - Read/pop command (dequeue/replace operation)
+          i_data - Input data to be enqueued (or used for replace)
+  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
+           o_empty - High when the queue is empty
+           o_data - Output data from the highest priority element
+*******************************************************************************/
+
 module register_array #(
     parameter bit ENQ_ENA = 0,  // if user would like to enable enqueue
     parameter int QUEUE_SIZE = 4,  // size of the queue

--- a/hwpq/register_array_pipelined/rtl/sim/register_array_pipelined_tb.sv
+++ b/hwpq/register_array_pipelined/rtl/sim/register_array_pipelined_tb.sv
@@ -379,8 +379,7 @@ module register_array_pipelined_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK); // should have no effects
+      repeat (2) @(posedge CLK);
     end
   endtask
 
@@ -418,8 +417,8 @@ module register_array_pipelined_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+
+      repeat (2) @(posedge CLK);
     end
   endtask
 
@@ -456,8 +455,8 @@ module register_array_pipelined_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+
+      repeat (2) @(posedge CLK);
     end
   endtask
 

--- a/hwpq/register_array_pipelined/rtl/sim/register_array_pipelined_tb.sv
+++ b/hwpq/register_array_pipelined/rtl/sim/register_array_pipelined_tb.sv
@@ -117,6 +117,8 @@ module register_array_pipelined_tb;
   // Clock generation: 10ns period
   always #5 CLK <= ~CLK;
 
+  int error_count = 0;
+
   initial begin
     // Initialize signals
     CLK = 0;
@@ -147,7 +149,7 @@ module register_array_pipelined_tb;
       enqueue(random_value);
     end
     assert (o_full)
-    else $error("The queue should be filled by the intialization!");
+    else begin error_count++; $error("The queue should be filled by the intialization!"); end;
 
     // Test Case 1: Dequeue nodes with ENQ_ENA enabled
     $display("\nTest Case 1: Dequeue Test (ENQ_ENA enabled)");
@@ -156,10 +158,10 @@ module register_array_pipelined_tb;
       if (!o_empty) begin
         assert (o_data == ref_queue_enq_1[0])
         else
-          $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+          begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
       end else begin
         assert (o_data == '0)
-        else $error("Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+        else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -170,10 +172,10 @@ module register_array_pipelined_tb;
       enqueue(random_value);
       assert (o_data == ref_queue_enq_1[0])
       else
-        $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+        begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
     assert (o_full)
-    else $error("The queue should be filled after enqueue!");
+    else begin error_count++; $error("The queue should be filled after enqueue!"); end;
 
     // Test Case 3: Replace nodes with ENQ_ENA enabled
     $display("\nTest Case 3: Replace Test (ENQ_ENA enabled)");
@@ -182,7 +184,7 @@ module register_array_pipelined_tb;
       replace(random_value);
       assert (o_data == ref_queue_enq_1[0])
       else
-        $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+        begin error_count++; $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
 
     // Test case 4: Random opertaion for 50 times
@@ -195,25 +197,25 @@ module register_array_pipelined_tb;
           enqueue(random_value);
           assert (o_data == ref_queue_enq_1[0])
           else
-            $error(
+            begin error_count++; $error(
                 "Random Enqueue: Node value mismatch -> expected %d, got %d",
                 ref_queue_enq_1[0],
                 o_data
-            );
+            ); end;
         end
         DEQUEUE: begin
           dequeue();
           if (!o_empty) begin
             assert (o_data == ref_queue_enq_1[0])
             else
-              $error(
+              begin error_count++; $error(
                   "Random Dequeue: Node value mismatch -> expected %d, got %d",
                   ref_queue_enq_1[0],
                   o_data
-              );
+              ); end;
           end else begin
             assert (o_data == '0)
-            else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+            else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
         REPLACE: begin
@@ -221,11 +223,11 @@ module register_array_pipelined_tb;
           replace(random_value);
           assert (o_data == ref_queue_enq_1[0])
           else
-            $error(
+            begin error_count++; $error(
                 "Random Replace: Node value mismatch -> expected %d, got %d",
                 ref_queue_enq_1[0],
                 o_data
-            );
+            ); end;
         end
       endcase
     end
@@ -252,16 +254,16 @@ module register_array_pipelined_tb;
 
     // Test Case 5: Dequeue Test with ENQ_ENA disabled
     $display("\nTest Case 5: Dequeue Test (ENQ_ENA disabled)");
-    assert (o_full) else $error("The queue should be filled by the intialization!");
+    assert (o_full) else begin error_count++; $error("The queue should be filled by the intialization!"); end;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue_enq_0[0])
         else
-          $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+          begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
       end else begin
         assert (o_data == 'd0)
-        else $error("Dequeue: Node value mismatch -> expected %d, got %d", 'd0, o_data);
+        else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", 'd0, o_data); end;
       end
     end
 
@@ -274,10 +276,10 @@ module register_array_pipelined_tb;
       enqueue(random_value);
       assert (o_data == ref_queue_enq_0[0])
       else
-        $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+        begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
     end
     assert (o_data == o_data_prev)
-    else $error("The queue should not have change!");
+    else begin error_count++; $error("The queue should not have change!"); end;
     begin
       bit queues_match;
       bit error_flag;
@@ -293,10 +295,10 @@ module register_array_pipelined_tb;
           end
         end
       end
-      assert (!error_flag) else $error("The queue should not have change!");
+      assert (!error_flag) else begin error_count++; $error("The queue should not have change!"); end;
     end
     assert (!o_full && !o_empty)
-    else $error("The queue should not do anything!");
+    else begin error_count++; $error("The queue should not do anything!"); end;
 
     // Test Case 7: Test Replace operation with ENQ_ENA disabled
     $display("\nTest Case 7: Replace Test (ENQ_ENA disabled)");
@@ -305,7 +307,7 @@ module register_array_pipelined_tb;
       replace(random_value);
       assert (o_data == ref_queue_enq_0[0])
       else
-        $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+        begin error_count++; $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
     end
 
     // Test case 8: Random opertaion for 50 times
@@ -318,14 +320,14 @@ module register_array_pipelined_tb;
           if (!o_empty) begin
             assert (o_data == ref_queue_enq_0[0])
             else
-              $error(
+              begin error_count++; $error(
                   "Random Dequeue: Node value mismatch -> expected %d, got %d",
                   ref_queue_enq_0[0],
                   o_data
-              );
+              ); end;
           end else begin
             assert (o_data == '0)
-            else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+            else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
         REPLACE: begin
@@ -333,17 +335,22 @@ module register_array_pipelined_tb;
           replace(random_value);
           assert (o_data == ref_queue_enq_0[0])
           else
-            $error(
+            begin error_count++; $error(
                 "Random Replace: Node value mismatch -> expected %d, got %d",
                 ref_queue_enq_0[0],
                 o_data
-            );
+            ); end;
         end
       endcase
     end
 
-    $display("\nTest completed!");
-    $finish;
+    if (error_count == 0) begin
+      $display("\nTest completed!");
+      $finish;
+    end else begin
+      $display("\n%0d error(s) detected during simulation.", error_count);
+      $fatal(1, "Test FAILED with %0d error(s).", error_count);
+    end
   end
 
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);

--- a/hwpq/register_array_pipelined/rtl/sim/register_array_pipelined_tb.sv
+++ b/hwpq/register_array_pipelined/rtl/sim/register_array_pipelined_tb.sv
@@ -356,21 +356,27 @@ module register_array_pipelined_tb;
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     begin
       if (!o_full) begin
-        if (current_mode == ENABLED) begin
-          i_wrt_ena = 1;
-          i_read_ena = 0;
-          i_data_ena = value;
+        case (current_mode)
+          ENABLED: begin
+            i_wrt_ena = 1;
+            i_read_ena = 0;
+            i_data_ena = value;
 
-          ref_queue_enq_1[ref_queue_enq_1_size] = value;
-          ref_queue_enq_1_size++;
-      
-          rsort_ena();
-        end else if (current_mode == DISABLED) begin
-          i_wrt_dis = 1;
-          i_read_dis = 0;
-          i_data_dis = value;
-//          $display("Enqueue attempt with ENQ_ENA disabled - should have no effect");
-        end
+            ref_queue_enq_1[ref_queue_enq_1_size] = value;
+            ref_queue_enq_1_size++;
+
+            rsort_ena();
+          end
+          DISABLED: begin
+            i_wrt_dis = 1;
+            i_read_dis = 0;
+            i_data_dis = value;
+//            $display("Enqueue attempt with ENQ_ENA disabled - should have no effect");
+          end
+          default: begin
+            $display("Enqueue: Invalid mode, skipping enqueue");
+          end
+        endcase
       end else begin
         $display("Enqueue: Queue full, skipping enqueue");
       end
@@ -386,29 +392,33 @@ module register_array_pipelined_tb;
   task automatic dequeue();
     begin
       if (!o_empty) begin
-        if (current_mode == ENABLED) begin
-          i_wrt_ena  = 0;
-          i_read_ena = 1;
-          i_data_ena = 0;
+        case (current_mode)
+          ENABLED: begin
+            i_wrt_ena  = 0;
+            i_read_ena = 1;
+            i_data_ena = 0;
 
-          for (int i = 0; i < ref_queue_enq_1_size - 1; i++) begin
-            ref_queue_enq_1[i] = ref_queue_enq_1[i+1];
+            for (int i = 0; i < ref_queue_enq_1_size - 1; i++) begin
+              ref_queue_enq_1[i] = ref_queue_enq_1[i+1];
+            end
+            ref_queue_enq_1[ref_queue_enq_1_size-1] = '0;
+            ref_queue_enq_1_size--;
           end
-          ref_queue_enq_1[ref_queue_enq_1_size-1] = '0; 
-          ref_queue_enq_1_size--;
+          DISABLED: begin
+            i_wrt_dis  = 0;
+            i_read_dis = 1;
+            i_data_dis = 0;
 
-        end else if (current_mode == DISABLED) begin
-          i_wrt_dis  = 0;
-          i_read_dis = 1;
-          i_data_dis = 0;
-
-          for (int i = 0; i < ref_queue_enq_0_size - 1; i++) begin
-            ref_queue_enq_0[i] = ref_queue_enq_0[i+1];
+            for (int i = 0; i < ref_queue_enq_0_size - 1; i++) begin
+              ref_queue_enq_0[i] = ref_queue_enq_0[i+1];
+            end
+            ref_queue_enq_0[ref_queue_enq_0_size-1] = '0;
+            ref_queue_enq_0_size--;
           end
-          ref_queue_enq_0[ref_queue_enq_0_size-1] = '0; 
-          ref_queue_enq_0_size--;
-
-        end
+          default: begin
+            $display("Dequeue: Invalid mode, skipping dequeue");
+          end
+        endcase
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
@@ -424,32 +434,38 @@ module register_array_pipelined_tb;
 
   task automatic replace(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (current_mode == ENABLED) begin
-        i_wrt_ena  = 1;
-        i_read_ena = 1;
-        i_data_ena = value;
-        if (o_empty) begin
-          ref_queue_enq_1[ref_queue_enq_1_size] = value;
-          ref_queue_enq_1_size++;
-          
-          rsort_ena();
-        end else begin
-          ref_queue_enq_1[0] = value;
-          rsort_ena();
+      case (current_mode)
+        ENABLED: begin
+          i_wrt_ena  = 1;
+          i_read_ena = 1;
+          i_data_ena = value;
+          if (o_empty) begin
+            ref_queue_enq_1[ref_queue_enq_1_size] = value;
+            ref_queue_enq_1_size++;
+
+            rsort_ena();
+          end else begin
+            ref_queue_enq_1[0] = value;
+            rsort_ena();
+          end
         end
-      end else if (current_mode == DISABLED) begin
-        i_wrt_dis  = 1;
-        i_read_dis = 1;
-        i_data_dis = value;
-        if (o_empty) begin
-          ref_queue_enq_0[ref_queue_enq_0_size] = value;
-          ref_queue_enq_0_size++;
-          rsort_dis();
-        end else begin
-          ref_queue_enq_0[0] = value;
-          rsort_dis();
+        DISABLED: begin
+          i_wrt_dis  = 1;
+          i_read_dis = 1;
+          i_data_dis = value;
+          if (o_empty) begin
+            ref_queue_enq_0[ref_queue_enq_0_size] = value;
+            ref_queue_enq_0_size++;
+            rsort_dis();
+          end else begin
+            ref_queue_enq_0[0] = value;
+            rsort_dis();
+          end
         end
-      end
+        default: begin
+          $display("Replace: Invalid mode, skipping replace");
+        end
+      endcase
       @(posedge CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
@@ -462,22 +478,28 @@ module register_array_pipelined_tb;
 
   task automatic replace_init(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (current_mode == ENABLED) begin
-        i_wrt_ena  = 1;
-        i_read_ena = 1;
-        i_data_ena = value;
-      end else if (current_mode == DISABLED) begin
-        i_wrt_dis  = 1;
-        i_read_dis = 1;
-        i_data_dis = value;
-      end
+      case (current_mode)
+        ENABLED: begin
+          i_wrt_ena  = 1;
+          i_read_ena = 1;
+          i_data_ena = value;
+        end
+        DISABLED: begin
+          i_wrt_dis  = 1;
+          i_read_dis = 1;
+          i_data_dis = value;
+        end
+        default: begin
+          $display("Replace: Invalid mode, skipping replace");
+        end
+      endcase
       @(posedge CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) @(posedge CLK);
-      else if (current_mode == DISABLED) @(posedge CLK);
+
+      @(posedge CLK);
     end
   endtask
 

--- a/hwpq/register_array_pipelined/rtl/src/register_array_pipelined.sv
+++ b/hwpq/register_array_pipelined/rtl/src/register_array_pipelined.sv
@@ -1,5 +1,26 @@
 `default_nettype none
 
+/*******************************************************************************
+  Module Name: register_array_pipelined
+  Date: 2026/06/21
+  Description: A pipelined version of the register array priority queue that
+               splits the array-wide compare-and-swap operation across two
+               clock cycles (even-indexed pairs, then odd-indexed pairs) to
+               shorten the combinational path and reach higher clock
+               frequencies.
+  Parameters: ENQ_ENA - Enables the enqueue datapath when set
+              QUEUE_SIZE - Maximum number of elements in the priority queue
+              DATA_WIDTH - Bit width of data elements
+  Inputs: i_CLK - System clock
+          i_RSTn - Active-low reset signal
+          i_wrt - Write/insert command (enqueue/replace operation)
+          i_read - Read/pop command (dequeue/replace operation)
+          i_data - Input data to be enqueued (or used for replace)
+  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
+           o_empty - High when the queue is empty
+           o_data - Output data from the highest priority element
+*******************************************************************************/
+
 module register_array_pipelined #(
     parameter bit ENQ_ENA = 1,  // if user would like to enable enqueue
     parameter int QUEUE_SIZE = 4,  // size of the queue

--- a/hwpq/register_tree/rtl/sim/register_tree_tb.sv
+++ b/hwpq/register_tree/rtl/sim/register_tree_tb.sv
@@ -114,6 +114,8 @@ module register_tree_tb;
   // Clock generation: 10ns period
   always #5 CLK <= ~CLK;
 
+  int error_count = 0;
+
   initial begin
     // Initialize signals
     CLK = 0;
@@ -143,16 +145,16 @@ module register_tree_tb;
       random_value = $urandom_range(1, 1023);
       enqueue(random_value);
     end
-    assert (o_full) else $error("The queue should be filled by the intialization!");
+    assert (o_full) else begin error_count++; $error("The queue should be filled by the intialization!"); end;
 
     // Test Case 1: Dequeue nodes with ENQ_ENA enabled
     $display("\nTest Case 1: Dequeue Test (ENQ_ENA enabled)");
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
       if (!o_empty) begin
-        assert (o_data == ref_queue_enq_1[0]) else $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+        assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
       end else begin
-        assert (o_data == '0) else $error("Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+        assert (o_data == '0) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -161,16 +163,16 @@ module register_tree_tb;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       random_value = $urandom_range(1, 1023);
       enqueue(random_value);
-      assert (o_data == ref_queue_enq_1[0]) else $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+      assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
-    assert (o_full) else $error("The queue should be filled after enqueue!");
+    assert (o_full) else begin error_count++; $error("The queue should be filled after enqueue!"); end;
 
     // Test Case 3: Replace nodes with ENQ_ENA enabled
     $display("\nTest Case 3: Replace Test (ENQ_ENA enabled)");
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       random_value = $urandom_range(1, 1023);
       replace(random_value);
-      assert (o_data == ref_queue_enq_1[0]) else $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+      assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
 
     // Test case 4: Random opertaion for 50 times
@@ -181,20 +183,20 @@ module register_tree_tb;
         ENQUEUE: begin
           random_value = $urandom_range(1, 1023);
           enqueue(random_value);
-          assert (o_data == ref_queue_enq_1[0]) else $error("Random Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+          assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Random Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
         end
         DEQUEUE: begin
           dequeue();
           if (!o_empty) begin
-            assert (o_data == ref_queue_enq_1[0]) else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+            assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
           end else begin
-            assert (o_data == '0) else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+            assert (o_data == '0) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
         REPLACE: begin
           random_value = $urandom_range(1, 1023);
           replace(random_value);
-          assert (o_data == ref_queue_enq_1[0]) else $error("Random Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+          assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Random Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
         end
       endcase
     end
@@ -224,16 +226,16 @@ module register_tree_tb;
     // Test Case 4: Dequeue Test with ENQ_ENA disabled
     $display("\nTest Case 4: Dequeue Test (ENQ_ENA disabled)");
     assert (o_full)
-    else $error("The queue should be filled by the intialization!");
+    else begin error_count++; $error("The queue should be filled by the intialization!"); end;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue_enq_0[0])
         else
-          $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+          begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
       end else begin
         assert (o_data == 'd0)
-        else $error("Dequeue: Node value mismatch -> expected %d, got %d", 'd0, o_data);
+        else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", 'd0, o_data); end;
       end
     end
 
@@ -246,9 +248,9 @@ module register_tree_tb;
       enqueue(random_value);
       assert (o_data == ref_queue_enq_0[0])
       else
-        $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+        begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
     end
-    assert (o_data == o_data_prev) else $error("The queue should not have change!");
+    assert (o_data == o_data_prev) else begin error_count++; $error("The queue should not have change!"); end;
     begin
       bit queues_match;
       bit error_flag;
@@ -264,9 +266,9 @@ module register_tree_tb;
           end
         end
       end
-      assert (!error_flag) else $error("The queue should not have change!");
+      assert (!error_flag) else begin error_count++; $error("The queue should not have change!"); end;
     end
-    assert (!o_full && !o_empty) else $error("The queue should not do anything!");
+    assert (!o_full && !o_empty) else begin error_count++; $error("The queue should not do anything!"); end;
 
     // Test Case 6: Test Replace operation with ENQ_ENA disabled
     $display("\nTest Case 6: Replace Test (ENQ_ENA disabled)");
@@ -275,7 +277,7 @@ module register_tree_tb;
       replace(random_value);
       assert (o_data == ref_queue_enq_0[0])
       else
-        $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+        begin error_count++; $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
     end
 
     // Test case 8: Random opertaion for 50 times
@@ -288,14 +290,14 @@ module register_tree_tb;
           if (!o_empty) begin
             assert (o_data == ref_queue_enq_0[0])
             else
-              $error(
+              begin error_count++; $error(
                   "Random Dequeue: Node value mismatch -> expected %d, got %d",
                   ref_queue_enq_0[0],
                   o_data
-              );
+              ); end;
           end else begin
             assert (o_data == '0)
-            else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+            else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
         REPLACE: begin
@@ -303,17 +305,22 @@ module register_tree_tb;
           replace(random_value);
           assert (o_data == ref_queue_enq_0[0])
           else
-            $error(
+            begin error_count++; $error(
                 "Random Replace: Node value mismatch -> expected %d, got %d",
                 ref_queue_enq_0[0],
                 o_data
-            );
+            ); end;
         end
       endcase
     end
 
-    $display("\nTest completed!");
-    $finish;
+    if (error_count == 0) begin
+      $display("\nTest completed!");
+      $finish;
+    end else begin
+      $display("\n%0d error(s) detected during simulation.", error_count);
+      $fatal(1, "Test FAILED with %0d error(s).", error_count);
+    end
   end
 
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);

--- a/hwpq/register_tree/rtl/sim/register_tree_tb.sv
+++ b/hwpq/register_tree/rtl/sim/register_tree_tb.sv
@@ -326,21 +326,26 @@ module register_tree_tb;
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     begin
       if (!o_full) begin
-        if (current_mode == ENABLED) begin
-          i_wrt_ena = 1;
-          i_read_ena = 0;
-          i_data_ena = value;
+        case (current_mode)
+          ENABLED: begin
+            i_wrt_ena = 1;
+            i_read_ena = 0;
+            i_data_ena = value;
 
-          ref_queue_enq_1[ref_queue_enq_1_size] = value;
-          ref_queue_enq_1_size++;
-      
-          rsort_ena();
-        end else if (current_mode == DISABLED) begin
-          i_wrt_dis = 1;
-          i_read_dis = 0;
-          i_data_dis = value;
-//          $display("Enqueue attempt with ENQ_ENA disabled - should have no effect");
-        end
+            ref_queue_enq_1[ref_queue_enq_1_size] = value;
+            ref_queue_enq_1_size++;
+        
+            rsort_ena();
+          end
+          DISABLED: begin
+            i_wrt_dis = 1;
+            i_read_dis = 0;
+            i_data_dis = value;
+          end
+          default: begin
+            $display("Enqueue: Invalid mode, skipping enqueue");
+          end 
+          endcase
       end else begin
         $display("Enqueue: Queue full, skipping enqueue");
       end
@@ -349,15 +354,25 @@ module register_tree_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat ($clog2(QUEUE_SIZE)) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK); // should have no effects
+      case (current_mode)
+        ENABLED: begin
+          repeat ($clog2(QUEUE_SIZE)) @(posedge CLK);
+        end
+        DISABLED: begin
+          repeat (2) @(posedge CLK); // should have no effects
+        end
+        default: begin
+          $display("Enqueue: Invalid mode, skipping enqueue");
+        end
+      endcase
     end
   endtask
 
   task automatic dequeue();
     begin
       if (!o_empty) begin
-        if (current_mode == ENABLED) begin
+        case (current_mode)
+        ENABLED: begin        
           i_wrt_ena  = 0;
           i_read_ena = 1;
           i_data_ena = 0;
@@ -367,8 +382,8 @@ module register_tree_tb;
           end
           ref_queue_enq_1[ref_queue_enq_1_size-1] = '0; 
           ref_queue_enq_1_size--;
-
-        end else if (current_mode == DISABLED) begin
+        end 
+        DISABLED: begin
           i_wrt_dis  = 0;
           i_read_dis = 1;
           i_data_dis = 0;
@@ -378,8 +393,10 @@ module register_tree_tb;
           end
           ref_queue_enq_0[ref_queue_enq_0_size-1] = '0; 
           ref_queue_enq_0_size--;
-
         end
+        default:
+          $display("Invalid option, skipping dequeue");
+        endcase
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
@@ -395,7 +412,8 @@ module register_tree_tb;
 
   task automatic replace(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (current_mode == ENABLED) begin
+      case (current_mode)
+      ENABLED: begin
         i_wrt_ena  = 1;
         i_read_ena = 1;
         i_data_ena = value;
@@ -408,7 +426,8 @@ module register_tree_tb;
           ref_queue_enq_1[0] = value;
           rsort_ena();
         end
-      end else if (current_mode == DISABLED) begin
+      end 
+      DISABLED: begin
         i_wrt_dis  = 1;
         i_read_dis = 1;
         i_data_dis = value;
@@ -421,6 +440,7 @@ module register_tree_tb;
           rsort_dis();
         end
       end
+      endcase
       @(posedge CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
@@ -432,15 +452,18 @@ module register_tree_tb;
 
   task automatic replace_init(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (current_mode == ENABLED) begin
-        i_wrt_ena  = 1;
-        i_read_ena = 1;
-        i_data_ena = value;
-      end else if (current_mode == DISABLED) begin
-        i_wrt_dis  = 1;
-        i_read_dis = 1;
-        i_data_dis = value;
-      end
+      case(current_mode)
+        ENABLED: begin
+          i_wrt_ena  = 1;
+          i_read_ena = 1;
+          i_data_ena = value;
+        end
+        DISABLED: begin
+          i_wrt_dis  = 1;
+          i_read_dis = 1;
+          i_data_dis = value;
+        end
+      endcase
       @(posedge CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;

--- a/hwpq/register_tree/rtl/sim/register_tree_tb.sv
+++ b/hwpq/register_tree/rtl/sim/register_tree_tb.sv
@@ -388,8 +388,8 @@ module register_tree_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+      
+      repeat (2) @(posedge CLK);
     end
   endtask
 
@@ -426,9 +426,8 @@ module register_tree_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
-    end
+      repeat (2) @(posedge CLK); 
+    end  
   endtask
 
   task automatic replace_init(input logic [DATA_WIDTH-1:0] value);
@@ -447,8 +446,7 @@ module register_tree_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+      repeat (2) @(posedge CLK);
     end
   endtask
 

--- a/hwpq/register_tree/rtl/src/register_tree.sv
+++ b/hwpq/register_tree/rtl/src/register_tree.sv
@@ -1,5 +1,27 @@
 `default_nettype none
 
+/*******************************************************************************
+  Module Name: register_tree
+  Date: 2026/06/22
+  Description: A register-based priority queue that preserves the heap
+               property across a binary tree of registers, closely
+               resembling a software heap. Enqueue searches for the leftmost
+               invalid entry and reorders the tree; dequeue and replace
+               remove/update the root in a single cycle while alternating-
+               level compare-and-swap operations restore heap order.
+  Parameters: ENQ_ENA - Enables the enqueue datapath when set
+              QUEUE_SIZE - Maximum number of elements in the priority queue
+              DATA_WIDTH - Bit width of data elements
+  Inputs: i_CLK - System clock
+          i_RSTn - Active-low reset signal
+          i_wrt - Write/insert command (enqueue/replace operation)
+          i_read - Read/pop command (dequeue/replace operation)
+          i_data - Input data to be enqueued (or used for replace)
+  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
+           o_empty - High when the queue is empty
+           o_data - Output data from the highest priority element
+*******************************************************************************/
+
 module register_tree #(
     parameter bit ENQ_ENA = 1,    // Define if user would like to enable enqueue
     parameter int QUEUE_SIZE = 4095,

--- a/hwpq/register_tree_pipelined/rtl/sim/register_tree_pipelined_tb.sv
+++ b/hwpq/register_tree_pipelined/rtl/sim/register_tree_pipelined_tb.sv
@@ -117,6 +117,8 @@ module register_tree_pipelined_tb;
   // Clock generation: 10ns period
   always #5 CLK <= ~CLK;
 
+  int error_count = 0;
+
   initial begin
     // Initialize signals
     CLK = 0;
@@ -147,7 +149,7 @@ module register_tree_pipelined_tb;
       enqueue(random_value);
     end
     assert (o_full)
-    else $error("The queue should be filled by the intialization!");
+    else begin error_count++; $error("The queue should be filled by the intialization!"); end;
 
     // Test Case 1: Dequeue nodes with ENQ_ENA enabled
     $display("\nTest Case 1: Dequeue Test (ENQ_ENA enabled)");
@@ -156,10 +158,10 @@ module register_tree_pipelined_tb;
       if (!o_empty) begin
         assert (o_data == ref_queue_enq_1[0])
         else
-          $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+          begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
       end else begin
         assert (o_data == '0)
-        else $error("Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+        else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -170,10 +172,10 @@ module register_tree_pipelined_tb;
       enqueue(random_value);
       assert (o_data == ref_queue_enq_1[0])
       else
-        $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+        begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
     assert (o_full)
-    else $error("The queue should be filled after enqueue!");
+    else begin error_count++; $error("The queue should be filled after enqueue!"); end;
 
     // Test Case 3: Replace nodes with ENQ_ENA enabled
     $display("\nTest Case 3: Replace Test (ENQ_ENA enabled)");
@@ -182,7 +184,7 @@ module register_tree_pipelined_tb;
       replace(random_value);
       assert (o_data == ref_queue_enq_1[0])
       else
-        $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+        begin error_count++; $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
 
     // Test case 4: Random opertaion for 50 times
@@ -195,25 +197,25 @@ module register_tree_pipelined_tb;
           enqueue(random_value);
           assert (o_data == ref_queue_enq_1[0])
           else
-            $error(
+            begin error_count++; $error(
                 "Random Enqueue: Node value mismatch -> expected %d, got %d",
                 ref_queue_enq_1[0],
                 o_data
-            );
+            ); end;
         end
         DEQUEUE: begin
           dequeue();
           if (!o_empty) begin
             assert (o_data == ref_queue_enq_1[0])
             else
-              $error(
+              begin error_count++; $error(
                   "Random Dequeue: Node value mismatch -> expected %d, got %d",
                   ref_queue_enq_1[0],
                   o_data
-              );
+              ); end;
           end else begin
             assert (o_data == '0)
-            else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+            else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
         REPLACE: begin
@@ -221,11 +223,11 @@ module register_tree_pipelined_tb;
           replace(random_value);
           assert (o_data == ref_queue_enq_1[0])
           else
-            $error(
+            begin error_count++; $error(
                 "Random Replace: Node value mismatch -> expected %d, got %d",
                 ref_queue_enq_1[0],
                 o_data
-            );
+            ); end;
         end
       endcase
     end
@@ -255,16 +257,16 @@ module register_tree_pipelined_tb;
     // Test Case 4: Dequeue Test with ENQ_ENA disabled
     $display("\nTest Case 4: Dequeue Test (ENQ_ENA disabled)");
     assert (o_full)
-    else $error("The queue should be filled by the intialization!");
+    else begin error_count++; $error("The queue should be filled by the intialization!"); end;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue_enq_0[0])
         else
-          $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+          begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
       end else begin
         assert (o_data == 'd0)
-        else $error("Dequeue: Node value mismatch -> expected %d, got %d", 'd0, o_data);
+        else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", 'd0, o_data); end;
       end
     end
 
@@ -277,9 +279,9 @@ module register_tree_pipelined_tb;
       enqueue(random_value);
       assert (o_data == ref_queue_enq_0[0])
       else
-        $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+        begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
     end
-    assert (o_data == o_data_prev) else $error("The queue should not have change!");
+    assert (o_data == o_data_prev) else begin error_count++; $error("The queue should not have change!"); end;
     begin
       bit queues_match;
       bit error_flag;
@@ -295,9 +297,9 @@ module register_tree_pipelined_tb;
           end
         end
       end
-      assert (!error_flag) else $error("The queue should not have change!");
+      assert (!error_flag) else begin error_count++; $error("The queue should not have change!"); end;
     end
-    assert (!o_full && !o_empty) else $error("The queue should not do anything!");
+    assert (!o_full && !o_empty) else begin error_count++; $error("The queue should not do anything!"); end;
 
     // Test Case 6: Test Replace operation with ENQ_ENA disabled
     $display("\nTest Case 6: Replace Test (ENQ_ENA disabled)");
@@ -306,7 +308,7 @@ module register_tree_pipelined_tb;
       replace(random_value);
       assert (o_data == ref_queue_enq_0[0])
       else
-        $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+        begin error_count++; $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
     end
 
     // Test case 8: Random opertaion for 50 times
@@ -319,14 +321,14 @@ module register_tree_pipelined_tb;
           if (!o_empty) begin
             assert (o_data == ref_queue_enq_0[0])
             else
-              $error(
+              begin error_count++; $error(
                   "Random Dequeue: Node value mismatch -> expected %d, got %d",
                   ref_queue_enq_0[0],
                   o_data
-              );
+              ); end;
           end else begin
             assert (o_data == '0)
-            else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+            else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
         REPLACE: begin
@@ -334,17 +336,22 @@ module register_tree_pipelined_tb;
           replace(random_value);
           assert (o_data == ref_queue_enq_0[0])
           else
-            $error(
+            begin error_count++; $error(
                 "Random Replace: Node value mismatch -> expected %d, got %d",
                 ref_queue_enq_0[0],
                 o_data
-            );
+            ); end;
         end
       endcase
     end
 
-    $display("\nTest completed!");
-    $finish;
+    if (error_count == 0) begin
+      $display("\nTest completed!");
+      $finish;
+    end else begin
+      $display("\n%0d error(s) detected during simulation.", error_count);
+      $fatal(1, "Test FAILED with %0d error(s).", error_count);
+    end
   end
 
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);

--- a/hwpq/register_tree_pipelined/rtl/sim/register_tree_pipelined_tb.sv
+++ b/hwpq/register_tree_pipelined/rtl/sim/register_tree_pipelined_tb.sv
@@ -419,8 +419,8 @@ module register_tree_pipelined_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+
+      repeat (2) @(posedge CLK);
     end
   endtask
 
@@ -457,8 +457,8 @@ module register_tree_pipelined_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+
+      repeat (2) @(posedge CLK);
     end
   endtask
 
@@ -478,8 +478,8 @@ module register_tree_pipelined_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+
+      repeat (2) @(posedge CLK);
     end
   endtask
 

--- a/hwpq/register_tree_pipelined/rtl/sim/register_tree_pipelined_tb.sv
+++ b/hwpq/register_tree_pipelined/rtl/sim/register_tree_pipelined_tb.sv
@@ -357,21 +357,27 @@ module register_tree_pipelined_tb;
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     begin
       if (!o_full) begin
-        if (current_mode == ENABLED) begin
-          i_wrt_ena = 1;
-          i_read_ena = 0;
-          i_data_ena = value;
+        case (current_mode)
+          ENABLED: begin
+            i_wrt_ena = 1;
+            i_read_ena = 0;
+            i_data_ena = value;
 
-          ref_queue_enq_1[ref_queue_enq_1_size] = value;
-          ref_queue_enq_1_size++;
-      
-          rsort_ena();
-        end else if (current_mode == DISABLED) begin
-          i_wrt_dis = 1;
-          i_read_dis = 0;
-          i_data_dis = value;
-//          $display("Enqueue attempt with ENQ_ENA disabled - should have no effect");
-        end
+            ref_queue_enq_1[ref_queue_enq_1_size] = value;
+            ref_queue_enq_1_size++;
+
+            rsort_ena();
+          end
+          DISABLED: begin
+            i_wrt_dis = 1;
+            i_read_dis = 0;
+            i_data_dis = value;
+//            $display("Enqueue attempt with ENQ_ENA disabled - should have no effect");
+          end
+          default: begin
+            $display("Enqueue: Invalid mode, skipping enqueue");
+          end
+        endcase
       end else begin
         $display("Enqueue: Queue full, skipping enqueue");
       end
@@ -380,37 +386,50 @@ module register_tree_pipelined_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat ($clog2(QUEUE_SIZE)) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK); // should have no effects
+      case (current_mode)
+        ENABLED: begin
+          repeat ($clog2(QUEUE_SIZE)) @(posedge CLK);
+        end
+        DISABLED: begin
+          repeat (2) @(posedge CLK); // should have no effects
+        end
+        default: begin
+          $display("Enqueue: Invalid mode, skipping enqueue");
+        end
+      endcase
     end
   endtask
 
   task automatic dequeue();
     begin
       if (!o_empty) begin
-        if (current_mode == ENABLED) begin
-          i_wrt_ena  = 0;
-          i_read_ena = 1;
-          i_data_ena = 0;
+        case (current_mode)
+          ENABLED: begin
+            i_wrt_ena  = 0;
+            i_read_ena = 1;
+            i_data_ena = 0;
 
-          for (int i = 0; i < ref_queue_enq_1_size - 1; i++) begin
-            ref_queue_enq_1[i] = ref_queue_enq_1[i+1];
+            for (int i = 0; i < ref_queue_enq_1_size - 1; i++) begin
+              ref_queue_enq_1[i] = ref_queue_enq_1[i+1];
+            end
+            ref_queue_enq_1[ref_queue_enq_1_size-1] = '0;
+            ref_queue_enq_1_size--;
           end
-          ref_queue_enq_1[ref_queue_enq_1_size-1] = '0; 
-          ref_queue_enq_1_size--;
+          DISABLED: begin
+            i_wrt_dis  = 0;
+            i_read_dis = 1;
+            i_data_dis = 0;
 
-        end else if (current_mode == DISABLED) begin
-          i_wrt_dis  = 0;
-          i_read_dis = 1;
-          i_data_dis = 0;
-
-          for (int i = 0; i < ref_queue_enq_0_size - 1; i++) begin
-            ref_queue_enq_0[i] = ref_queue_enq_0[i+1];
+            for (int i = 0; i < ref_queue_enq_0_size - 1; i++) begin
+              ref_queue_enq_0[i] = ref_queue_enq_0[i+1];
+            end
+            ref_queue_enq_0[ref_queue_enq_0_size-1] = '0;
+            ref_queue_enq_0_size--;
           end
-          ref_queue_enq_0[ref_queue_enq_0_size-1] = '0; 
-          ref_queue_enq_0_size--;
-
-        end
+          default: begin
+            $display("Dequeue: Invalid mode, skipping dequeue");
+          end
+        endcase
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
@@ -426,32 +445,38 @@ module register_tree_pipelined_tb;
 
   task automatic replace(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (current_mode == ENABLED) begin
-        i_wrt_ena  = 1;
-        i_read_ena = 1;
-        i_data_ena = value;
-        if (o_empty) begin
-          ref_queue_enq_1[ref_queue_enq_1_size] = value;
-          ref_queue_enq_1_size++;
-          
-          rsort_ena();
-        end else begin
-          ref_queue_enq_1[0] = value;
-          rsort_ena();
+      case (current_mode)
+        ENABLED: begin
+          i_wrt_ena  = 1;
+          i_read_ena = 1;
+          i_data_ena = value;
+          if (o_empty) begin
+            ref_queue_enq_1[ref_queue_enq_1_size] = value;
+            ref_queue_enq_1_size++;
+
+            rsort_ena();
+          end else begin
+            ref_queue_enq_1[0] = value;
+            rsort_ena();
+          end
         end
-      end else if (current_mode == DISABLED) begin
-        i_wrt_dis  = 1;
-        i_read_dis = 1;
-        i_data_dis = value;
-        if (o_empty) begin
-          ref_queue_enq_0[ref_queue_enq_0_size] = value;
-          ref_queue_enq_0_size++;
-          rsort_dis();
-        end else begin
-          ref_queue_enq_0[0] = value;
-          rsort_dis();
+        DISABLED: begin
+          i_wrt_dis  = 1;
+          i_read_dis = 1;
+          i_data_dis = value;
+          if (o_empty) begin
+            ref_queue_enq_0[ref_queue_enq_0_size] = value;
+            ref_queue_enq_0_size++;
+            rsort_dis();
+          end else begin
+            ref_queue_enq_0[0] = value;
+            rsort_dis();
+          end
         end
-      end
+        default: begin
+          $display("Replace: Invalid mode, skipping replace");
+        end
+      endcase
       @(posedge CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
@@ -464,15 +489,21 @@ module register_tree_pipelined_tb;
 
   task automatic replace_init(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (current_mode == ENABLED) begin
-        i_wrt_ena  = 1;
-        i_read_ena = 1;
-        i_data_ena = value;
-      end else if (current_mode == DISABLED) begin
-        i_wrt_dis  = 1;
-        i_read_dis = 1;
-        i_data_dis = value;
-      end
+      case (current_mode)
+        ENABLED: begin
+          i_wrt_ena  = 1;
+          i_read_ena = 1;
+          i_data_ena = value;
+        end
+        DISABLED: begin
+          i_wrt_dis  = 1;
+          i_read_dis = 1;
+          i_data_dis = value;
+        end
+        default: begin
+          $display("Replace: Invalid mode, skipping replace");
+        end
+      endcase
       @(posedge CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;

--- a/hwpq/register_tree_pipelined/rtl/src/register_tree_pipelined.sv
+++ b/hwpq/register_tree_pipelined/rtl/src/register_tree_pipelined.sv
@@ -1,5 +1,25 @@
 `default_nettype none
 
+/*******************************************************************************
+  Module Name: register_tree_pipelined
+  Date: 2026/06/21
+  Description: A pipelined version of the register tree architecture that
+               divides the compare-and-swap logic between clock cycles to
+               reduce combinational path length, at the cost of enqueue
+               taking two cycles to propagate a new entry into place.
+  Parameters: ENQ_ENA - Enables the enqueue datapath when set
+              QUEUE_SIZE - Maximum number of elements in the priority queue
+              DATA_WIDTH - Bit width of data elements
+  Inputs: i_CLK - System clock
+          i_RSTn - Active-low reset signal
+          i_wrt - Write/insert command (enqueue/replace operation)
+          i_read - Read/pop command (dequeue/replace operation)
+          i_data - Input data to be enqueued (or used for replace)
+  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
+           o_empty - High when the queue is empty
+           o_data - Output data from the highest priority element
+*******************************************************************************/
+
 module register_tree_pipelined #(
     parameter bit ENQ_ENA = 1,
     parameter int QUEUE_SIZE = 15,

--- a/hwpq/systolic_array/rtl/sim/systolic_array_bug_tb.sv
+++ b/hwpq/systolic_array/rtl/sim/systolic_array_bug_tb.sv
@@ -50,6 +50,8 @@ module systolic_array_tb;
   // Clock generation: 10ns period
   always #5 CLK <= ~CLK;
 
+  int error_count = 0;
+
   initial begin
     // Initialize signals
     CLK = 0;
@@ -103,10 +105,10 @@ module systolic_array_tb;
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue[0])
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
         assert (o_data == '0)
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -152,10 +154,10 @@ module systolic_array_tb;
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue[0])
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
         assert (o_data == '0)
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -200,10 +202,10 @@ module systolic_array_tb;
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue[0])
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
         assert (o_data == '0)
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -249,15 +251,20 @@ module systolic_array_tb;
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue[0])
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
         assert (o_data == '0)
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
-    $display("\nTest completed! ");
-    $finish;
+    if (error_count == 0) begin
+      $display("\nTest completed!");
+      $finish;
+    end else begin
+      $display("\n%0d error(s) detected during simulation.", error_count);
+      $fatal(1, "Test FAILED with %0d error(s).", error_count);
+    end
   end
 
   // Task to read root node

--- a/hwpq/systolic_array/rtl/sim/systolic_array_bug_tb.sv
+++ b/hwpq/systolic_array/rtl/sim/systolic_array_bug_tb.sv
@@ -68,6 +68,14 @@ module systolic_array_tb;
     // Test Case 1: Successive decreasing numbers in IB
     $display("\nTest Case 1: Successive decreasing numbers in IB");
     ref_queue.delete();
+
+    /* Icarus Verilog (12.0) cannot force an unpacked array, so the DUT buffers are seeded
+      one element at a time with plain hierarchical assignments instead of
+        `force u_SystolicArray.IB = '{16'd1, 16'd6, 16'd4, 16'd2};`
+      which fails with "Assignment to an entire array or to an array slice is not yet supported".
+      Forcing a single word fails too with "cannot force to the word of a variable array". 
+      The same applies to the other test cases below. */
+    
     u_SystolicArray.IB[0] = 16'd1;
     u_SystolicArray.IB[1] = 16'd6;
     u_SystolicArray.IB[2] = 16'd4;

--- a/hwpq/systolic_array/rtl/sim/systolic_array_tb.sv
+++ b/hwpq/systolic_array/rtl/sim/systolic_array_tb.sv
@@ -51,6 +51,8 @@ module systolic_array_tb;
   // Clock generation: 10ns period
   always #5 CLK <= ~CLK;
 
+  int error_count = 0;
+
   initial begin
     // Initialize signals
     CLK = 0;
@@ -79,10 +81,10 @@ module systolic_array_tb;
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue[0])
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
         assert (o_data == '0)
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -93,7 +95,7 @@ module systolic_array_tb;
       random_value = $urandom_range(0, 1024);
       enqueue(random_value);
       assert (o_data == ref_queue[0])
-      else $error("Enqueue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+      else begin error_count++; $error("Enqueue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
     end
 
     // Test Case 3: Replace nodes
@@ -103,7 +105,7 @@ module systolic_array_tb;
       random_value = $urandom_range(0, 1024);
       replace(random_value);
       assert (o_data == ref_queue[0])
-      else $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+      else begin error_count++; $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
     end
 
     // Test Case 4: Stress Test
@@ -112,13 +114,13 @@ module systolic_array_tb;
     $display("\nTest Case 4: Stress Test");
     for (int i = 0; i < 100; i++) begin
       random_value = $urandom_range(0, 1024);
-      random_operation = t_operation'($urandom_range(1,3));
+      random_operation = t_operation'($urandom_range(1, 3));  
       case (random_operation)
         ENQUEUE: begin
           enqueue(random_value);
           assert (o_data == ref_queue[0])
           else
-            $error("Enqueue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+            begin error_count++; $error("Enqueue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
         end
 
         DEQUEUE: begin
@@ -126,10 +128,10 @@ module systolic_array_tb;
           if (!o_empty) begin
             assert (o_data == ref_queue[0])
             else
-              $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+              begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
           end else begin
             assert (o_data == '0)
-            else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+            else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
 
@@ -137,7 +139,7 @@ module systolic_array_tb;
           replace(random_value);
           assert (o_data == ref_queue[0])
           else
-            $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+            begin error_count++; $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
         end
 
         default: begin
@@ -146,8 +148,13 @@ module systolic_array_tb;
       endcase
     end
 
-    $display("\nTest completed! ");
-    $finish;
+    if (error_count == 0) begin
+      $display("\nTest completed!");
+      $finish;
+    end else begin
+      $display("\n%0d error(s) detected during simulation.", error_count);
+      $fatal(1, "Test FAILED with %0d error(s).", error_count);
+    end
   end
 
   // Task to write to the end of the queue

--- a/hwpq/systolic_array/rtl/src/systolic_array.sv
+++ b/hwpq/systolic_array/rtl/src/systolic_array.sv
@@ -1,5 +1,26 @@
 `default_nettype none
 
+/*******************************************************************************
+  Module Name: systolic_array
+  Date: 2026/06/18
+  Description: A priority queue implementation using a systolic array of an
+               input buffer (IB) and output buffer (OB). New nodes shift
+               through the IB, swapping bubble-sort style with adjacent OB
+               nodes so higher-priority (larger f) values migrate into the
+               OB; dequeuing the OB head propagates a "bubble" back through
+               the array to refill it.
+  Parameters: QUEUE_SIZE - Maximum number of elements in the priority queue
+              DATA_WIDTH - Bit width of the node's evaluation value (f)
+  Inputs: i_CLK - System clock
+          i_RSTn - Active-low reset signal
+          i_wrt - Enqueue signal
+          i_read - Dequeue signal
+          i_data - Node data input
+  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
+           o_empty - High when the queue is empty
+           o_data - Node data output (highest priority element)
+*******************************************************************************/
+
 module systolic_array #(
     parameter int QUEUE_SIZE = 4,  // Size of the buffers (number of positions)
     parameter int DATA_WIDTH = 16  // Width of the node data (evaluation function value 'f')

--- a/scripts/run_sim.sh
+++ b/scripts/run_sim.sh
@@ -7,7 +7,7 @@
 #   <testbench_file>  path to the testbench .sv (e.g. hwpq/register_tree/rtl/sim/register_tree_tb.sv)
 #   <top_module>      top-level module name declared in the testbench (e.g. register_tree_tb)
 #
-set -euo pipefail
+set -eu
 
 MODULE="$1"
 TB="$2"
@@ -37,13 +37,12 @@ iverilog -g2012 -Wall -s "${TOP}" -o "${BUILD}/sim.vvp" "${PKGS[@]}" "${REST[@]}
 
 echo "==> Running ${MODULE}"
 vvp "${BUILD}/sim.vvp" | tee "${LOG}"
+status="${PIPESTATUS[0]}"
 
 echo "==> Checking results for ${MODULE}"
-status=0
 
-if grep -inE 'error|mismatch|assertion|\bfail' "${LOG}"; then
-  echo "::error::${MODULE}: assertion/error output detected in simulation log"
-  status=1
+if [ "${status}" -ne 0 ]; then
+  echo "::error::${MODULE}: testbench exited with status ${status}"
 fi
 
 if ! grep -qiE 'test[[:space:]]+completed' "${LOG}"; then


### PR DESCRIPTION
Addresses the remaining review comments from PR [#14](https://github.com/realise-lab/hwpq/pull/14) (github actions)

- **use testbench exit status instead of log-scraping:** every testbench now tracks an error_count and calls $fatal at the end if any assertion failed, so run_sim.sh checks the real exit status. pipefail was removed since it would otherwise trip set -e on the vvp | tee pipe before the exit status could be captured via PIPESTATUS, and nothign else used it so i removed rather than disabling + reenabling

- **drop redundant if-else branches**: several testbenches had if `(current_mode == ENABLED) X; else if (current_mode == DISABLED) X;` collapsed to unconditional statements.
- **enum dispatch via case instead of if-else**: testbenches branching on the current_mode (ENABLED/DISABLED) enum now use `case (current_mode) ... default: ... endcase`.
- **explain the iverilog force limitation**: addresses a review comment on systolic_array_bug_tb.sv asking (i think?) why IB/OB/size are seeded per-element instead of via force . iverilog 12.0 doesn't support force for these.
- **restore/add module header comments** restored the bram_tree.sv docstring, and added matching header blocks to the other architecture modules that lacked one.

did not address the container repo issue per Johnson's guidance