### PR TITLE
Refactor/interface naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ hwpq/register_array/rtl_elaboration/
 obj_dir
 *.vvp
 *.vcd
+
+build/

--- a/hwpq/bram_tree/rtl/sim/bram_tree_tb.sv
+++ b/hwpq/bram_tree/rtl/sim/bram_tree_tb.sv
@@ -11,8 +11,8 @@ module bram_tree_tb;
   logic   [DATA_WIDTH-1:0] i_data;
 
   // Output signals
-  logic                   o_full;
-  logic                   o_empty;
+  logic                   o_write_ready;
+  logic                   o_read_ready;
   logic   [DATA_WIDTH-1:0] o_data;
 
   // Reference array for verification
@@ -37,8 +37,8 @@ module bram_tree_tb;
       .i_wrt(i_wrt),
       .i_read(i_read),
       .i_data(i_data),
-      .o_full(o_full),
-      .o_empty(o_empty),
+      .o_write_ready(o_write_ready),
+      .o_read_ready(o_read_ready),
       .o_data(o_data)
   );
 
@@ -73,7 +73,7 @@ module bram_tree_tb;
     $display("\nTest Case 1: Dequeue Test");
     for (i = 0; i < QUEUE_SIZE; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue[0])
         else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
@@ -125,7 +125,7 @@ module bram_tree_tb;
 
         DEQUEUE: begin
           dequeue();
-          if (!o_empty) begin
+          if (o_read_ready) begin
             assert (o_data == ref_queue[0])
             else
               begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
@@ -162,7 +162,7 @@ module bram_tree_tb;
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     logic [DATA_WIDTH-1:0] tmp;
     begin
-      if (!o_full) begin
+      if (o_write_ready) begin
         i_wrt  = 1;
         i_read = 0;
         i_data = value;
@@ -192,7 +192,7 @@ module bram_tree_tb;
   // Task to read root node
   task automatic dequeue();
     begin
-      if (!o_empty) begin
+      if (o_read_ready) begin
         i_wrt  = 0;
         i_read = 1;
         for (int i = 0; i < ref_size - 1; i++) begin

--- a/hwpq/bram_tree/rtl/sim/bram_tree_tb.sv
+++ b/hwpq/bram_tree/rtl/sim/bram_tree_tb.sv
@@ -45,6 +45,8 @@ module bram_tree_tb;
   // Clock generation: 10ns period
   always #5 CLK <= ~CLK;
 
+  int error_count = 0;
+
   initial begin
     // Initialize signals
     CLK = 0;
@@ -73,10 +75,10 @@ module bram_tree_tb;
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue[0])
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
         assert (o_data == '0)
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -90,7 +92,7 @@ module bram_tree_tb;
       random_value = $urandom_range(0, 1024);
       enqueue(random_value);
       assert (o_data == ref_queue[0])
-      else $error("Enqueue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+      else begin error_count++; $error("Enqueue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
     end
 
 
@@ -103,7 +105,7 @@ module bram_tree_tb;
       random_value = $urandom_range(0, 1024);
       replace(random_value);
       assert (o_data == ref_queue[0])
-      else $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+      else begin error_count++; $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
     end
 
     
@@ -118,7 +120,7 @@ module bram_tree_tb;
           enqueue(random_value);
           assert (o_data == ref_queue[0])
           else
-            $error("Enqueue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+            begin error_count++; $error("Enqueue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
         end
 
         DEQUEUE: begin
@@ -126,10 +128,10 @@ module bram_tree_tb;
           if (!o_empty) begin
             assert (o_data == ref_queue[0])
             else
-              $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+              begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
           end else begin
             assert (o_data == '0)
-            else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+            else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
 
@@ -137,7 +139,7 @@ module bram_tree_tb;
           replace(random_value);
           assert (o_data == ref_queue[0])
           else
-            $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+            begin error_count++; $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
         end
 
         default: begin
@@ -147,8 +149,13 @@ module bram_tree_tb;
     end
     
 
-    $display("\nTest completed! ");
-    $finish;
+    if (error_count == 0) begin
+      $display("\nTest completed!");
+      $finish;
+    end else begin
+      $display("\n%0d error(s) detected during simulation.", error_count);
+      $fatal(1, "Test FAILED with %0d error(s).", error_count);
+    end
   end
 
   // Task to write to the end of the queue

--- a/hwpq/bram_tree/rtl/sim/bram_tree_tb.sv
+++ b/hwpq/bram_tree/rtl/sim/bram_tree_tb.sv
@@ -2,8 +2,8 @@ import bram_tree_pkg::*;
 
 module bram_tree_tb;
   // Clock and reset signals
-  logic                   CLK;
-  logic                   RSTn;
+  logic                   i_CLK;
+  logic                   i_RSTn;
 
   // Input signals
   logic                   i_wrt;
@@ -32,8 +32,8 @@ module bram_tree_tb;
 
   // Instantiate the register_tree module
   bram_tree uut (
-      .CLK(CLK),
-      .RSTn(RSTn),
+      .i_CLK(i_CLK),
+      .i_RSTn(i_RSTn),
       .i_wrt(i_wrt),
       .i_read(i_read),
       .i_data(i_data),
@@ -43,22 +43,22 @@ module bram_tree_tb;
   );
 
   // Clock generation: 10ns period
-  always #5 CLK <= ~CLK;
+  always #5 i_CLK <= ~i_CLK;
 
   int error_count = 0;
 
   initial begin
     // Initialize signals
-    CLK = 0;
-    RSTn = 0;
+    i_CLK = 0;
+    i_RSTn = 0;
     i_wrt = 0;
     i_read = 0;
     i_data = 0;
 
     // Reset the module
-    @(posedge CLK);
-    RSTn = 1;
-    repeat (2) @(posedge CLK);
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    repeat (2) @(posedge i_CLK);
 
     // Initialize the reference queue, sort the reference queue, and write to the queue
     for (i = 0; i < QUEUE_SIZE; i++) begin
@@ -66,7 +66,7 @@ module bram_tree_tb;
       enqueue(random_value);
     end
 
-    repeat (16) @(posedge CLK);
+    repeat (16) @(posedge i_CLK);
 
     // Test Case 1: Dequeue nodes
     // Dequeue nodes for QUEUE_SIZE times
@@ -82,7 +82,7 @@ module bram_tree_tb;
       end
     end
 
-    repeat (16) @(posedge CLK);
+    repeat (16) @(posedge i_CLK);
 
     
     // Test Case 2: Enqueue nodes
@@ -96,7 +96,7 @@ module bram_tree_tb;
     end
 
 
-    repeat (16) @(posedge CLK);
+    repeat (16) @(posedge i_CLK);
     
     // Test Case 3: Replace nodes
     // Replace root node for QUEUE_SIZE times
@@ -182,10 +182,10 @@ module bram_tree_tb;
       end else begin
         $display("Enqueue: Queue full, skipping enqueue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (6 * ($clog2(QUEUE_SIZE + 1) + 1)) @(posedge CLK);
+      repeat (6 * ($clog2(QUEUE_SIZE + 1) + 1)) @(posedge i_CLK);
     end
   endtask
 
@@ -204,10 +204,10 @@ module bram_tree_tb;
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (6 * ($clog2(QUEUE_SIZE + 1) + 1)) @(posedge CLK);
+      repeat (6 * ($clog2(QUEUE_SIZE + 1) + 1)) @(posedge i_CLK);
     end
   endtask
 
@@ -233,10 +233,10 @@ module bram_tree_tb;
         $display("Replace: Queue empty, skipping replace");
       end
       
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (6 * ($clog2(QUEUE_SIZE + 1) + 1)) @(posedge CLK);
+      repeat (6 * ($clog2(QUEUE_SIZE + 1) + 1)) @(posedge i_CLK);
     end
   endtask
 

--- a/hwpq/bram_tree/rtl/src/bram_tree.sv
+++ b/hwpq/bram_tree/rtl/src/bram_tree.sv
@@ -1,7 +1,7 @@
 /*******************************************************************************
   Module Name: bram_tree
   Date: 2025/03/05
-  Description: A priority queue implementation using a binary min-heap structure
+  Description: A priority queue implementation using a binary max-heap structure
                stored in block RAM (BRAM). Supports enqueue, dequeue, and replace
                operations.
   Parameters: QUEUE_SIZE - Maximum number of elements in the priority queue
@@ -14,7 +14,6 @@
   Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
            o_empty - High when the queue is empty
            o_data - Output data from the highest priority element
-           o_ready - High if the tree is done propagating/rebalancing & ready for another read/write
 *******************************************************************************/
 
 package bram_tree_pkg;

--- a/hwpq/bram_tree/rtl/src/bram_tree.sv
+++ b/hwpq/bram_tree/rtl/src/bram_tree.sv
@@ -11,8 +11,8 @@
           i_wrt - Write/insert command (enqueue operation)
           i_read - Read/pop command (dequeue operation)
           i_data - Input data to be enqueued
-  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
-           o_empty - High when the queue is empty
+  Outputs: o_write_ready - High when the queue has room to accept a write
+           o_read_ready - High when the queue holds data available to read
            o_data - Output data from the highest priority element
 *******************************************************************************/
 
@@ -48,8 +48,8 @@ module bram_tree #(
     input  logic                  i_read,   // Read/pop command
     input  logic [DATA_WIDTH-1:0] i_data,   // Input data
     // Outputs
-    output logic                  o_full,   // High if the heap is full
-    output logic                  o_empty,  // High if the heap is empty
+    output logic                  o_write_ready,   // High if the queue can accept a write
+    output logic                  o_read_ready,  // High if the queue has data to read
     output logic [DATA_WIDTH-1:0] o_data    // Output data (Root node)
 );
 
@@ -158,7 +158,7 @@ module bram_tree #(
 
     case (state)
       IDLE: begin
-        if (i_wrt && !i_read && !o_full) begin // --- ENQUEUE ---
+        if (i_wrt && !i_read && o_write_ready) begin // --- ENQUEUE ---
           if (queue_size == 0) begin
             addr_a = 0;
             we_a = 1;
@@ -178,7 +178,7 @@ module bram_tree #(
             next_state = ENQUEUE_COMPARE_ROOT;
           end
           next_queue_size = queue_size + 1;
-        end else if (!i_wrt && i_read && !o_empty) begin // --- DEQUEUE ---
+        end else if (!i_wrt && i_read && o_read_ready) begin // --- DEQUEUE ---
           addr_a = 0;
           we_a = 1;
 
@@ -682,8 +682,8 @@ module bram_tree #(
     endcase
   end
 
-  assign o_full  = (queue_size == QUEUE_SIZE);
-  assign o_empty = (queue_size == 0);
+  assign o_write_ready  = !(queue_size == QUEUE_SIZE);
+  assign o_read_ready = !(queue_size == 0);
   assign o_data  = (queue_size == 0) ? 0 : out_reg;
   assign ready   = (state == IDLE);
 endmodule

--- a/hwpq/bram_tree/rtl/src/bram_tree.sv
+++ b/hwpq/bram_tree/rtl/src/bram_tree.sv
@@ -6,8 +6,8 @@
                operations.
   Parameters: QUEUE_SIZE - Maximum number of elements in the priority queue
               DATA_WIDTH - Bit width of data elements
-  Inputs: CLK - System clock
-          RSTn - Active-low reset signal
+  Inputs: i_CLK - System clock
+          i_RSTn - Active-low reset signal
           i_wrt - Write/insert command (enqueue operation)
           i_read - Read/pop command (dequeue operation)
           i_data - Input data to be enqueued
@@ -41,8 +41,8 @@ module bram_tree #(
 		parameter integer QUEUE_SIZE = bram_tree_pkg::QUEUE_SIZE,
     parameter integer DATA_WIDTH = bram_tree_pkg::DATA_WIDTH
 )(
-    input  logic                  CLK,
-    input  logic                  RSTn,
+    input  logic                  i_CLK,
+    input  logic                  i_RSTn,
     // Inputs
     input  logic                  i_wrt,    // Write/insert command
     input  logic                  i_read,   // Read/pop command
@@ -110,12 +110,12 @@ module bram_tree #(
   logic [DATA_WIDTH-1:0] second_greatest, next_second_greatest;
 
   rams_tdp_rf_rf bram_inst (
-    .clka (CLK), .ena(1'b1), .wea(we_a), .addra(addr_a), .dia(din_a), .doa(dout_a),
-    .clkb (CLK), .enb(1'b1), .web(we_b), .addrb(addr_b), .dib(din_b), .dob(dout_b)
+    .clka (i_CLK), .ena(1'b1), .wea(we_a), .addra(addr_a), .dia(din_a), .doa(dout_a),
+    .clkb (i_CLK), .enb(1'b1), .web(we_b), .addrb(addr_b), .dib(din_b), .dob(dout_b)
   );
 
-  always_ff @(posedge CLK or negedge RSTn) begin : fsm_seq
-    if (!RSTn) begin
+  always_ff @(posedge i_CLK or negedge i_RSTn) begin : fsm_seq
+    if (!i_RSTn) begin
       state         <= IDLE;
       queue_size    <= 0;
       curr          <= '0;

--- a/hwpq/bram_tree/rtl/src/bram_tree.sv
+++ b/hwpq/bram_tree/rtl/src/bram_tree.sv
@@ -1,3 +1,22 @@
+/*******************************************************************************
+  Module Name: bram_tree
+  Date: 2025/03/05
+  Description: A priority queue implementation using a binary min-heap structure
+               stored in block RAM (BRAM). Supports enqueue, dequeue, and replace
+               operations.
+  Parameters: QUEUE_SIZE - Maximum number of elements in the priority queue
+              DATA_WIDTH - Bit width of data elements
+  Inputs: CLK - System clock
+          RSTn - Active-low reset signal
+          i_wrt - Write/insert command (enqueue operation)
+          i_read - Read/pop command (dequeue operation)
+          i_data - Input data to be enqueued
+  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
+           o_empty - High when the queue is empty
+           o_data - Output data from the highest priority element
+           o_ready - High if the tree is done propagating/rebalancing & ready for another read/write
+*******************************************************************************/
+
 package bram_tree_pkg;
   localparam integer DATA_WIDTH = 16;
   localparam integer QUEUE_SIZE = 7;

--- a/hwpq/bram_tree_pipelined/rtl/sim/pipelined_bram_tree_tb.sv
+++ b/hwpq/bram_tree_pipelined/rtl/sim/pipelined_bram_tree_tb.sv
@@ -50,6 +50,8 @@ module bram_tree_pipelined_tb;
   // Clock generation: 10ns period
   always #5 CLK <= ~CLK;
 
+  int error_count = 0;
+
   initial begin
     // Initialize signals
     CLK = 0;
@@ -81,10 +83,10 @@ module bram_tree_pipelined_tb;
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue[0])
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
         assert (o_data == '0)
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -109,7 +111,7 @@ module bram_tree_pipelined_tb;
       random_value = DataWidth'(($urandom & ((1 << DataWidth) - 1)) % 1025);
       replace(random_value);
       assert (o_data == ref_queue[0])
-      else $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+      else begin error_count++; $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
     end
 
     // Test Case 3: Stress Test
@@ -124,10 +126,10 @@ module bram_tree_pipelined_tb;
           if (!o_empty) begin
             assert (o_data == ref_queue[0])
             else
-              $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+              begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
           end else begin
             assert (o_data == '0)
-            else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+            else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
 
@@ -135,7 +137,7 @@ module bram_tree_pipelined_tb;
           replace(random_value);
           assert (o_data == ref_queue[0])
           else
-            $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+            begin error_count++; $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
         end
 
         default: begin
@@ -144,8 +146,13 @@ module bram_tree_pipelined_tb;
       endcase
     end
 
-    $display("\nTest completed! ");
-    $finish;
+    if (error_count == 0) begin
+      $display("\nTest completed!");
+      $finish;
+    end else begin
+      $display("\n%0d error(s) detected during simulation.", error_count);
+      $fatal(1, "Test FAILED with %0d error(s).", error_count);
+    end
   end
 
   // Task to read root node

--- a/hwpq/bram_tree_pipelined/rtl/sim/pipelined_bram_tree_tb.sv
+++ b/hwpq/bram_tree_pipelined/rtl/sim/pipelined_bram_tree_tb.sv
@@ -4,8 +4,8 @@ module bram_tree_pipelined_tb;
   localparam integer DataWidth = 16;
 
   // Clock and reset signals
-  logic                   CLK;
-  logic                   RSTn;
+  logic                   i_CLK;
+  logic                   i_RSTn;
 
   // Input signals
   logic                   i_wrt;
@@ -37,8 +37,8 @@ module bram_tree_pipelined_tb;
       .QUEUE_SIZE(QueueSize),
       .DATA_WIDTH(DataWidth)
   ) uut (
-      .CLK(CLK),
-      .RSTn(RSTn),
+      .i_CLK(i_CLK),
+      .i_RSTn(i_RSTn),
       .i_wrt(i_wrt),
       .i_read(i_read),
       .i_data(i_data),
@@ -48,22 +48,22 @@ module bram_tree_pipelined_tb;
   );
 
   // Clock generation: 10ns period
-  always #5 CLK <= ~CLK;
+  always #5 i_CLK <= ~i_CLK;
 
   int error_count = 0;
 
   initial begin
     // Initialize signals
-    CLK = 0;
-    RSTn = 0;
+    i_CLK = 0;
+    i_RSTn = 0;
     i_wrt = 0;
     i_read = 0;
     i_data = 0;
 
     // Reset the module
-    @(posedge CLK);
-    RSTn = 1;
-    repeat (2) @(posedge CLK);
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    repeat (2) @(posedge i_CLK);
 
     // Initialize the reference queue, sort the reference queue, and write to the queue
     for (i = 0; i < QueueSize; i++) begin
@@ -74,7 +74,7 @@ module bram_tree_pipelined_tb;
     end
     rsort();
 
-    repeat (16) @(posedge CLK);
+    repeat (16) @(posedge i_CLK);
 
     // Test Case 1: Dequeue nodes
     // Dequeue nodes for QUEUE_SIZE times
@@ -91,9 +91,9 @@ module bram_tree_pipelined_tb;
     end
 
     /*// Reset the module
-    @(posedge CLK);
-    RSTn = 1;
-    repeat (2) @(posedge CLK);
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    repeat (2) @(posedge i_CLK);
 
     for (i = 0; i < QueueSize; i++) begin
       random_value = DataWidth'(($urandom & ((1 << DataWidth) - 1)) % 1025);
@@ -102,7 +102,7 @@ module bram_tree_pipelined_tb;
     end
     ref_queue.rsort();*/
     
-    repeat (16) @(posedge CLK);
+    repeat (16) @(posedge i_CLK);
 
     // Test Case 2: Replace nodes
     // Replace root node for QUEUE_SIZE times
@@ -169,10 +169,10 @@ module bram_tree_pipelined_tb;
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (24) @(posedge CLK);
+      repeat (24) @(posedge i_CLK);
     end
   endtask
 
@@ -190,10 +190,10 @@ module bram_tree_pipelined_tb;
         ref_queue[0] = value;
         rsort();
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (24) @(posedge CLK);
+      repeat (24) @(posedge i_CLK);
     end
   endtask
 
@@ -202,10 +202,10 @@ module bram_tree_pipelined_tb;
       i_wrt  = 1;
       i_read = 1;
       i_data = value;
-      repeat (1) @(posedge CLK);
+      repeat (1) @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (24) @(posedge CLK);
+      repeat (24) @(posedge i_CLK);
     end
   endtask
 

--- a/hwpq/bram_tree_pipelined/rtl/sim/pipelined_bram_tree_tb.sv
+++ b/hwpq/bram_tree_pipelined/rtl/sim/pipelined_bram_tree_tb.sv
@@ -13,8 +13,8 @@ module bram_tree_pipelined_tb;
   logic   [DataWidth-1:0] i_data;
 
   // Output signals
-  logic                   o_full;
-  logic                   o_empty;
+  logic                   o_write_ready;
+  logic                   o_read_ready;
   logic   [DataWidth-1:0] o_data;
 
   // Reference array for verification
@@ -42,8 +42,8 @@ module bram_tree_pipelined_tb;
       .i_wrt(i_wrt),
       .i_read(i_read),
       .i_data(i_data),
-      .o_full(o_full),
-      .o_empty(o_empty),
+      .o_write_ready(o_write_ready),
+      .o_read_ready(o_read_ready),
       .o_data(o_data)
   );
 
@@ -81,7 +81,7 @@ module bram_tree_pipelined_tb;
     $display("\nTest Case 1: Dequeue Test");
     for (i = 0; i < QueueSize/2; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue[0])
         else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
@@ -123,7 +123,7 @@ module bram_tree_pipelined_tb;
       case (random_operation)
         DEQUEUE: begin
           dequeue();
-          if (!o_empty) begin
+          if (o_read_ready) begin
             assert (o_data == ref_queue[0])
             else
               begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
@@ -158,7 +158,7 @@ module bram_tree_pipelined_tb;
   // Task to read root node
   task automatic dequeue();
     begin
-      if (!o_empty) begin
+      if (o_read_ready) begin
         i_wrt  = 0;
         i_read = 1;
         for (int i = 0; i < ref_queue_size - 1; i++) begin
@@ -182,7 +182,7 @@ module bram_tree_pipelined_tb;
       i_wrt  = 1;
       i_read = 1;
       i_data = value;
-      if (o_empty) begin
+      if (!o_read_ready) begin
         ref_queue[ref_queue_size] = value;
         ref_queue_size++;
         rsort();

--- a/hwpq/bram_tree_pipelined/rtl/src/bram_tree_pipelined.sv
+++ b/hwpq/bram_tree_pipelined/rtl/src/bram_tree_pipelined.sv
@@ -8,8 +8,8 @@
                for improved scalability over the non-pipelined BRAM tree.
   Parameters: QUEUE_SIZE - Maximum number of elements in the priority queue
               DATA_WIDTH - Bit width of data elements
-  Inputs: CLK - System clock
-          RSTn - Active-low reset signal
+  Inputs: i_CLK - System clock
+          i_RSTn - Active-low reset signal
           i_wrt - Write/insert command (enqueue operation)
           i_read - Read/pop command (dequeue operation)
           i_data - Input data to be inserted (or used for replace)
@@ -22,8 +22,8 @@ module bram_tree_pipelined #(
     parameter integer QUEUE_SIZE = 7,
     parameter integer DATA_WIDTH = 16
 ) (
-    input  logic                  CLK,
-    input  logic                  RSTn,
+    input  logic                  i_CLK,
+    input  logic                  i_RSTn,
     // Inputs
     input  logic                  i_wrt,    // Write/insert command
     input  logic                  i_read,   // Read/pop command
@@ -117,13 +117,13 @@ module bram_tree_pipelined #(
           .WIDTH(DATA_WIDTH),
           .DEPTH(NODES_NEEDED)
       ) bram_inst (
-          .clka (CLK),
+          .clka (i_CLK),
           .ena  (1'b1),
           .wea  (we_a[i]),
           .addra(addr_a[i]),
           .dia  (din_a[i]),
           .doa  (dout_a[i]),
-          .clkb (CLK),
+          .clkb (i_CLK),
           .enb  (1'b1),
           .web  (we_b[i]),
           .addrb(addr_b[i]),
@@ -150,8 +150,8 @@ module bram_tree_pipelined #(
   //-------------------------------------------------------------------------
   // FSM
   //-------------------------------------------------------------------------
-  always_ff @(posedge CLK or negedge RSTn) begin : fsm_seq
-    if (!RSTn) begin
+  always_ff @(posedge i_CLK or negedge i_RSTn) begin : fsm_seq
+    if (!i_RSTn) begin
       state <= IDLE;
     end else begin
       state <= next_state;
@@ -223,8 +223,8 @@ module bram_tree_pipelined #(
   //-------------------------------------------------------------------------
   // BRAM read&write, heap management
   //-------------------------------------------------------------------------
-  always_ff @(posedge CLK or negedge RSTn) begin : bram_seq
-    if (!RSTn) begin
+  always_ff @(posedge i_CLK or negedge i_RSTn) begin : bram_seq
+    if (!i_RSTn) begin
       parent_lvl <= '0;
       parent_idx <= '0;
       level_0 <= '1;
@@ -397,8 +397,8 @@ module bram_tree_pipelined #(
   //-------------------------------------------------------------------------
   // Queue size counter
   //-------------------------------------------------------------------------
-  always_ff @(posedge CLK or negedge RSTn) begin : queue_size_seq
-    if (!RSTn) begin
+  always_ff @(posedge i_CLK or negedge i_RSTn) begin : queue_size_seq
+    if (!i_RSTn) begin
       queue_size <= 0;
     end else begin
       queue_size <= next_queue_size;

--- a/hwpq/bram_tree_pipelined/rtl/src/bram_tree_pipelined.sv
+++ b/hwpq/bram_tree_pipelined/rtl/src/bram_tree_pipelined.sv
@@ -1,3 +1,24 @@
+/*******************************************************************************
+  Module Name: bram_tree_pipelined
+  Date: 2026/06/23
+  Description: A pipelined priority queue implementation using a binary max-heap
+               structure stored in block RAM, with the top few levels
+               kept in registers. Supports enqueue, dequeue, and replace
+               operations, trading throughput (one replace every four cycles)
+               for improved scalability over the non-pipelined BRAM tree.
+  Parameters: QUEUE_SIZE - Maximum number of elements in the priority queue
+              DATA_WIDTH - Bit width of data elements
+  Inputs: CLK - System clock
+          RSTn - Active-low reset signal
+          i_wrt - Write/insert command (enqueue operation)
+          i_read - Read/pop command (dequeue operation)
+          i_data - Input data to be inserted (or used for replace)
+  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
+           o_empty - High when the queue is empty
+           o_valid - High when o_data holds a valid output
+           o_data - Output data from the highest priority element
+*******************************************************************************/
+
 module bram_tree_pipelined #(
     parameter integer QUEUE_SIZE = 7,
     parameter integer DATA_WIDTH = 16

--- a/hwpq/bram_tree_pipelined/rtl/src/bram_tree_pipelined.sv
+++ b/hwpq/bram_tree_pipelined/rtl/src/bram_tree_pipelined.sv
@@ -13,9 +13,9 @@
           i_wrt - Write/insert command (enqueue operation)
           i_read - Read/pop command (dequeue operation)
           i_data - Input data to be inserted (or used for replace)
-  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
-           o_empty - High when the queue is empty
-           o_data - Output data from the highest priority element
+Outputs:    o_write_ready - High when the queue has room to accept a write
+            o_read_ready - High when the queue holds data available to read
+            o_data - Output data from the highest priority element
 *******************************************************************************/
 
 module bram_tree_pipelined #(
@@ -29,8 +29,8 @@ module bram_tree_pipelined #(
     input  logic                  i_read,   // Read/pop command
     input  logic [DATA_WIDTH-1:0] i_data,   // Data to be inserted (or used for replace)
     // Outputs
-    output logic                  o_full,   // High if the heap is full
-    output logic                  o_empty,  // High if the heap is empty
+    output logic                  o_write_ready,   // High if the queue can accept a write
+    output logic                  o_read_ready,  // High if the queue has data to read
     output logic [DATA_WIDTH-1:0] o_data    // Output data (popped value)
 );
 
@@ -425,8 +425,8 @@ module bram_tree_pipelined #(
   //-------------------------------------------------------------------------
   // Assignments for status and output.
   //-------------------------------------------------------------------------
-  assign o_full  = (queue_size == QUEUE_SIZE);
-  assign o_empty = (queue_size == 0);
+  assign o_write_ready  = !(queue_size == QUEUE_SIZE);
+  assign o_read_ready = !(queue_size == 0);
   assign o_data  = level_0;
 
 endmodule

--- a/hwpq/bram_tree_pipelined/rtl/src/bram_tree_pipelined.sv
+++ b/hwpq/bram_tree_pipelined/rtl/src/bram_tree_pipelined.sv
@@ -15,7 +15,6 @@
           i_data - Input data to be inserted (or used for replace)
   Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
            o_empty - High when the queue is empty
-           o_valid - High when o_data holds a valid output
            o_data - Output data from the highest priority element
 *******************************************************************************/
 

--- a/hwpq/hybrid_tree/rtl/sim/hybrid_tree_tb.sv
+++ b/hwpq/hybrid_tree/rtl/sim/hybrid_tree_tb.sv
@@ -4,8 +4,8 @@ module hybrid_tree_tb;
   localparam integer DataWidth = 16;
 
   // Clock and reset signals
-  logic                   CLK;
-  logic                   RSTn;
+  logic                   i_CLK;
+  logic                   i_RSTn;
 
   // Input signals
   logic                   i_wrt;
@@ -35,8 +35,8 @@ module hybrid_tree_tb;
       .QUEUE_SIZE(QueueSize),
       .DATA_WIDTH(DataWidth)
   ) uut (
-      .CLK(CLK),
-      .RSTn(RSTn),
+      .i_CLK(i_CLK),
+      .i_RSTn(i_RSTn),
       .i_wrt(i_wrt),
       .i_read(i_read),
       .i_data(i_data),
@@ -46,20 +46,20 @@ module hybrid_tree_tb;
   );
 
   // Clock generation: 10ns period
-  always #5 CLK <= ~CLK;
+  always #5 i_CLK <= ~i_CLK;
 
   initial begin
     // Initialize signals
-    CLK = 0;
-    RSTn = 0;
+    i_CLK = 0;
+    i_RSTn = 0;
     i_wrt = 0;
     i_read = 0;
     i_data = 0;
 
     // Reset the module
-    @(posedge CLK);
-    RSTn = 1;
-    @(posedge CLK);
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    @(posedge i_CLK);
 
     // Initialize the reference queue, sort the reference queue, and write to the queue
     for (int i = 0; i < QueueSize; i++) begin
@@ -102,7 +102,7 @@ module hybrid_tree_tb;
 
     uut.next_size = 4;
 
-    repeat (8) @(posedge CLK);
+    repeat (8) @(posedge i_CLK);
 
     // Test Case: Replace nodes
     $display("\nReplace Test");
@@ -128,10 +128,10 @@ module hybrid_tree_tb;
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (24) @(posedge CLK);
+      repeat (24) @(posedge i_CLK);
     end
   endtask
 
@@ -144,10 +144,10 @@ module hybrid_tree_tb;
       ref_queue.pop_front();
       ref_queue.push_back(value);
       ref_queue.rsort();
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (4) @(posedge CLK);
+      repeat (4) @(posedge i_CLK);
     end
   endtask
 

--- a/hwpq/hybrid_tree/rtl/sim/hybrid_tree_tb.sv
+++ b/hwpq/hybrid_tree/rtl/sim/hybrid_tree_tb.sv
@@ -13,8 +13,8 @@ module hybrid_tree_tb;
   logic   [DataWidth-1:0] i_data;
 
   // Output signals
-  logic                   o_full;
-  logic                   o_empty;
+  logic                   o_write_ready;
+  logic                   o_read_ready;
   logic   [DataWidth-1:0] o_data;
 
   // Reference array for verification
@@ -40,8 +40,8 @@ module hybrid_tree_tb;
       .i_wrt(i_wrt),
       .i_read(i_read),
       .i_data(i_data),
-      .o_full(o_full),
-      .o_empty(o_empty),
+      .o_write_ready(o_write_ready),
+      .o_read_ready(o_read_ready),
       .o_data(o_data)
   );
 
@@ -120,7 +120,7 @@ module hybrid_tree_tb;
   // Task to read root node
   task automatic dequeue();
     begin
-      if (!o_empty) begin
+      if (o_read_ready) begin
         i_wrt  = 0;
         i_read = 1;
         ref_queue.pop_front();

--- a/hwpq/hybrid_tree/rtl/sim/pipelined_bram_tree_tb.sv
+++ b/hwpq/hybrid_tree/rtl/sim/pipelined_bram_tree_tb.sv
@@ -4,8 +4,8 @@ module pipelined_bram_tree_tb;
   localparam integer DataWidth = 16;
 
   // Clock and reset signals
-  logic                   CLK;
-  logic                   RSTn;
+  logic                   i_CLK;
+  logic                   i_RSTn;
 
   // Input signals
   logic                   i_wrt;
@@ -36,8 +36,8 @@ module pipelined_bram_tree_tb;
       .QUEUE_SIZE(QueueSize),
       .DATA_WIDTH(DataWidth)
   ) uut (
-      .CLK(CLK),
-      .RSTn(RSTn),
+      .i_CLK(i_CLK),
+      .i_RSTn(i_RSTn),
       .i_wrt(i_wrt),
       .i_read(i_read),
       .i_data(i_data),
@@ -48,20 +48,20 @@ module pipelined_bram_tree_tb;
   );
 
   // Clock generation: 10ns period
-  always #5 CLK <= ~CLK;
+  always #5 i_CLK <= ~i_CLK;
 
   initial begin
     // Initialize signals
-    CLK = 0;
-    RSTn = 0;
+    i_CLK = 0;
+    i_RSTn = 0;
     i_wrt = 0;
     i_read = 0;
     i_data = 0;
 
     // Reset the module
-    @(posedge CLK);
-    RSTn = 1;
-    @(posedge CLK);
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    @(posedge i_CLK);
 
     // Initialize the reference queue, sort the reference queue, and write to the queue
     for (int i = 0; i < QueueSize; i++) begin
@@ -87,7 +87,7 @@ module pipelined_bram_tree_tb;
     uut.next_queue_size = QueueSize;
     uut.next_state = 0;
 
-    repeat (16) @(posedge CLK);
+    repeat (16) @(posedge i_CLK);
 
     // Test Case 1: Dequeue nodes
     // Dequeue nodes for QUEUE_SIZE times
@@ -126,7 +126,7 @@ module pipelined_bram_tree_tb;
     uut.next_queue_size = QueueSize;
     uut.next_state = 0;
 
-    repeat (16) @(posedge CLK);
+    repeat (16) @(posedge i_CLK);
 
     // Test Case 2: Replace nodes
     // Replace root node for QUEUE_SIZE times
@@ -185,10 +185,10 @@ module pipelined_bram_tree_tb;
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (24) @(posedge CLK);
+      repeat (24) @(posedge i_CLK);
     end
   endtask
 
@@ -201,10 +201,10 @@ module pipelined_bram_tree_tb;
       ref_queue.pop_front();
       ref_queue.push_back(value);
       ref_queue.rsort();
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (24) @(posedge CLK);
+      repeat (24) @(posedge i_CLK);
     end
   endtask
 

--- a/hwpq/hybrid_tree/rtl/sim/pipelined_bram_tree_tb.sv
+++ b/hwpq/hybrid_tree/rtl/sim/pipelined_bram_tree_tb.sv
@@ -13,8 +13,8 @@ module pipelined_bram_tree_tb;
   logic   [DataWidth-1:0] i_data;
 
   // Output signals
-  logic                   o_full;
-  logic                   o_empty;
+  logic                   o_write_ready;
+  logic                   o_read_ready;
   logic                   o_valid;
   logic   [DataWidth-1:0] o_data;
 
@@ -41,8 +41,8 @@ module pipelined_bram_tree_tb;
       .i_wrt(i_wrt),
       .i_read(i_read),
       .i_data(i_data),
-      .o_full(o_full),
-      .o_empty(o_empty),
+      .o_write_ready(o_write_ready),
+      .o_read_ready(o_read_ready),
       .o_valid(o_valid),
       .o_data(o_data)
   );
@@ -94,7 +94,7 @@ module pipelined_bram_tree_tb;
     $display("\nTest Case 1: Dequeue Test");
     for (int i = 0; i < QueueSize; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue[0])
         else $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
       end else begin
@@ -147,7 +147,7 @@ module pipelined_bram_tree_tb;
       case (random_operation)
         DEQUEUE: begin
           dequeue();
-          if (!o_empty) begin
+          if (o_read_ready) begin
             assert (o_data == ref_queue[0])
             else
               $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
@@ -177,7 +177,7 @@ module pipelined_bram_tree_tb;
   // Task to read root node
   task automatic dequeue();
     begin
-      if (!o_empty) begin
+      if (o_read_ready) begin
         i_wrt  = 0;
         i_read = 1;
         ref_queue.pop_front();

--- a/hwpq/hybrid_tree/rtl/src/hybrid_tree.sv
+++ b/hwpq/hybrid_tree/rtl/src/hybrid_tree.sv
@@ -1,3 +1,24 @@
+/*******************************************************************************
+  Module Name: hybrid_tree
+  Date: 2025/03/21
+  Description: A hybrid priority queue (Max H-PQ) that combines a register
+               array holding the root nodes of multiple BRAM-based trees. New
+               items replace the leftmost register entry and propagate down
+               the corresponding BRAM tree, while the register array is kept
+               sorted so each entry is >= its right neighbor. Supports
+               enqueue, dequeue, and replace operations.
+  Parameters: QUEUE_SIZE - Maximum number of elements in the priority queue
+              DATA_WIDTH - Bit width of data elements
+  Inputs: CLK - System clock
+          RSTn - Active-low reset signal
+          i_wrt - Write/insert command (enqueue operation)
+          i_read - Read/pop command (dequeue operation)
+          i_data - Input data to be inserted (or used for replace)
+  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
+           o_empty - High when the queue is empty
+           o_data - Output data from the highest priority element
+*******************************************************************************/
+
 module hybrid_tree #(
     parameter integer QUEUE_SIZE = 4,
     parameter integer DATA_WIDTH = 16

--- a/hwpq/hybrid_tree/rtl/src/hybrid_tree.sv
+++ b/hwpq/hybrid_tree/rtl/src/hybrid_tree.sv
@@ -9,8 +9,8 @@
                enqueue, dequeue, and replace operations.
   Parameters: QUEUE_SIZE - Maximum number of elements in the priority queue
               DATA_WIDTH - Bit width of data elements
-  Inputs: CLK - System clock
-          RSTn - Active-low reset signal
+  Inputs: i_CLK - System clock
+          i_RSTn - Active-low reset signal
           i_wrt - Write/insert command (enqueue operation)
           i_read - Read/pop command (dequeue operation)
           i_data - Input data to be inserted (or used for replace)
@@ -23,8 +23,8 @@ module hybrid_tree #(
     parameter integer QUEUE_SIZE = 4,
     parameter integer DATA_WIDTH = 16
 ) (
-    input  logic                  CLK,
-    input  logic                  RSTn,
+    input  logic                  i_CLK,
+    input  logic                  i_RSTn,
     // Inputs
     input  logic                  i_wrt,    // Write/insert command
     input  logic                  i_read,   // Read/pop command
@@ -93,8 +93,8 @@ module hybrid_tree #(
   logic [$clog2(QUEUE_SIZE)-1:0] next_size;
   logic empty, full;
 
-  always_ff @(posedge CLK or negedge RSTn) begin : queue_size_seq
-    if (!RSTn) begin
+  always_ff @(posedge i_CLK or negedge i_RSTn) begin : queue_size_seq
+    if (!i_RSTn) begin
       size <= 0;
     end else begin
       size <= next_size;
@@ -167,8 +167,8 @@ module hybrid_tree #(
           .DATA_WIDTH(DATA_WIDTH),
           .QUEUE_SIZE(BRAM_SIZE)
       ) bram_tree_inst (
-          .CLK(CLK),
-          .RSTn(RSTn),
+          .i_CLK(i_CLK),
+          .i_RSTn(i_RSTn),
           .i_wrt(bram_i_wrt[bram_tree_gen]),
           .i_read(bram_i_read[bram_tree_gen]),
           .i_data(bram_i_data[bram_tree_gen]),
@@ -183,8 +183,8 @@ module hybrid_tree #(
   //-------------------------------------------------------------------------
   // Regsiter Array Mamagement
   //-------------------------------------------------------------------------
-  always_ff @(posedge CLK or negedge RSTn) begin : array_seq
-    if (!RSTn) begin
+  always_ff @(posedge i_CLK or negedge i_RSTn) begin : array_seq
+    if (!i_RSTn) begin
       for (int i = 0; i < ARRAY_SIZE; i++) begin
         level_0_data[i]   <= '{default: 0};
         level_0_target[i] <= '{default: 0};

--- a/hwpq/hybrid_tree/rtl/src/hybrid_tree.sv
+++ b/hwpq/hybrid_tree/rtl/src/hybrid_tree.sv
@@ -14,8 +14,8 @@
           i_wrt - Write/insert command (enqueue operation)
           i_read - Read/pop command (dequeue operation)
           i_data - Input data to be inserted (or used for replace)
-  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
-           o_empty - High when the queue is empty
+  Outputs: o_write_ready - High when the queue has room to accept a write
+           o_read_ready - High when the queue holds data available to read
            o_data - Output data from the highest priority element
 *******************************************************************************/
 
@@ -30,8 +30,8 @@ module hybrid_tree #(
     input  logic                  i_read,   // Read/pop command
     input  logic [DATA_WIDTH-1:0] i_data,   // Data to be inserted (or used for replace)
     // Outputs
-    output logic                  o_full,   // High if the heap is full
-    output logic                  o_empty,  // High if the heap is empty
+    output logic                  o_write_ready,   // High if the queue can accept a write
+    output logic                  o_read_ready,  // High if the queue has data to read
     output logic [DATA_WIDTH-1:0] o_data    // Output data (popped value)
 );
 
@@ -120,8 +120,8 @@ module hybrid_tree #(
   logic bram_i_read[ARRAY_SIZE-1:0];
   logic [DATA_WIDTH-1:0] bram_i_data[ARRAY_SIZE-1:0];
   logic [DATA_WIDTH-1:0] next_bram_i_data[ARRAY_SIZE-1:0];
-  logic bram_o_full[ARRAY_SIZE-1:0];
-  logic bram_o_empty[ARRAY_SIZE-1:0];
+  logic bram_o_write_ready[ARRAY_SIZE-1:0];
+  logic bram_o_read_ready[ARRAY_SIZE-1:0];
   logic bram_o_valid[ARRAY_SIZE-1:0];
   logic [DATA_WIDTH-1:0] bram_o_data[ARRAY_SIZE-1:0];
   logic bram_enqueue[ARRAY_SIZE-1:0];
@@ -172,8 +172,8 @@ module hybrid_tree #(
           .i_wrt(bram_i_wrt[bram_tree_gen]),
           .i_read(bram_i_read[bram_tree_gen]),
           .i_data(bram_i_data[bram_tree_gen]),
-          .o_full(bram_o_full[bram_tree_gen]),
-          .o_empty(bram_o_empty[bram_tree_gen]),
+          .o_write_ready(bram_o_write_ready[bram_tree_gen]),
+          .o_read_ready(bram_o_read_ready[bram_tree_gen]),
           .o_valid(bram_o_valid[bram_tree_gen]),
           .o_data(bram_o_data[bram_tree_gen])
       );
@@ -295,19 +295,19 @@ module hybrid_tree #(
   always_comb begin : empty_check
     empty = (size == 0);
     for (int i = 0; i < ARRAY_SIZE; i++) begin
-      empty = empty & bram_o_empty[i];  // AND operation to ensure all are empty
+      empty = empty & !bram_o_read_ready[i];  // AND operation to ensure all are empty
     end
   end
 
   always_comb begin : full_check
     full = (size == ARRAY_SIZE);
     for (int i = 0; i < ARRAY_SIZE; i++) begin
-      full = full & bram_o_full[i];  // AND operation to ensure all are full
+      full = full & !bram_o_write_ready[i];  // AND operation to ensure all are full
     end
   end
 
-  assign o_empty = empty;
-  assign o_full  = full;
+  assign o_read_ready = !empty;
+  assign o_write_ready  = !full;
   assign o_data  = level_0_data[0];
 
 endmodule

--- a/hwpq/hybrid_tree/rtl/src/pipelined_bram_tree.sv
+++ b/hwpq/hybrid_tree/rtl/src/pipelined_bram_tree.sv
@@ -13,8 +13,8 @@
           i_wrt - Write/insert command (enqueue operation)
           i_read - Read/pop command (dequeue operation)
           i_data - Input data to be inserted (or used for replace)
-  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
-           o_empty - High when the queue is empty
+  Outputs: o_write_ready - High when the queue has room to accept a write
+           o_read_ready - High when the queue holds data available to read
            o_valid - High when o_data holds a valid output
            o_data - Output data from the highest priority element
 *******************************************************************************/
@@ -30,8 +30,8 @@ module pipelined_bram_tree #(
     input  logic                  i_read,   // Read/pop command
     input  logic [DATA_WIDTH-1:0] i_data,   // Data to be inserted (or used for replace)
     // Outputs
-    output logic                  o_full,   // High if the heap is full
-    output logic                  o_empty,  // High if the heap is empty
+    output logic                  o_write_ready,   // High if the queue can accept a write
+    output logic                  o_read_ready,  // High if the queue has data to read
     output logic                  o_valid,
     output logic [DATA_WIDTH-1:0] o_data    // Output data (popped value)
 );
@@ -443,8 +443,8 @@ module pipelined_bram_tree #(
   //-------------------------------------------------------------------------
   // Assignments for status and output.
   //-------------------------------------------------------------------------
-  assign o_full  = (queue_size >= QUEUE_SIZE);
-  assign o_empty = (queue_size <= 0);
+  assign o_write_ready  = !(queue_size >= QUEUE_SIZE);
+  assign o_read_ready = !(queue_size <= 0);
   assign o_valid = valid;
   assign o_data  = level_0;
 

--- a/hwpq/hybrid_tree/rtl/src/pipelined_bram_tree.sv
+++ b/hwpq/hybrid_tree/rtl/src/pipelined_bram_tree.sv
@@ -8,8 +8,8 @@
                enqueue, dequeue, and replace operations.
   Parameters: QUEUE_SIZE - Maximum number of elements in the sub-tree
               DATA_WIDTH - Bit width of data elements
-  Inputs: CLK - System clock
-          RSTn - Active-low reset signal
+  Inputs: i_CLK - System clock
+          i_RSTn - Active-low reset signal
           i_wrt - Write/insert command (enqueue operation)
           i_read - Read/pop command (dequeue operation)
           i_data - Input data to be inserted (or used for replace)
@@ -23,8 +23,8 @@ module pipelined_bram_tree #(
     parameter integer QUEUE_SIZE = 7,
     parameter integer DATA_WIDTH = 16
 ) (
-    input  logic                  CLK,
-    input  logic                  RSTn,
+    input  logic                  i_CLK,
+    input  logic                  i_RSTn,
     // Inputs
     input  logic                  i_wrt,    // Write/insert command
     input  logic                  i_read,   // Read/pop command
@@ -125,13 +125,13 @@ module pipelined_bram_tree #(
           .WIDTH(DATA_WIDTH),
           .DEPTH((1 << i))
       ) bram_inst (
-          .clka (CLK),
+          .clka (i_CLK),
           .ena  (1'b1),
           .wea  (we_a[i]),
           .addra(addr_a[i]),
           .dia  (din_a[i]),
           .doa  (dout_a[i]),
-          .clkb (CLK),
+          .clkb (i_CLK),
           .enb  (1'b1),
           .web  (we_b[i]),
           .addrb(addr_b[i]),
@@ -160,8 +160,8 @@ module pipelined_bram_tree #(
   // FSM
   //-------------------------------------------------------------------------
 
-  always_ff @(posedge CLK or negedge RSTn) begin : fsm_seq
-    if (!RSTn) begin
+  always_ff @(posedge i_CLK or negedge i_RSTn) begin : fsm_seq
+    if (!i_RSTn) begin
       state <= IDLE;
     end else begin
       state <= next_state;
@@ -234,8 +234,8 @@ module pipelined_bram_tree #(
   // BRAM read & write, heap management
   //-------------------------------------------------------------------------
 
-  always_ff @(posedge CLK or negedge RSTn) begin : bram_seq
-    if (!RSTn) begin
+  always_ff @(posedge i_CLK or negedge i_RSTn) begin : bram_seq
+    if (!i_RSTn) begin
       parent_lvl <= '0;
       parent_idx <= '0;
       level_0 <= '0;
@@ -417,8 +417,8 @@ module pipelined_bram_tree #(
   // Queue size counter
   //-------------------------------------------------------------------------
 
-  always_ff @(posedge CLK or negedge RSTn) begin : queue_size_seq
-    if (!RSTn) begin
+  always_ff @(posedge i_CLK or negedge i_RSTn) begin : queue_size_seq
+    if (!i_RSTn) begin
       queue_size <= 0;
     end else begin
       queue_size <= next_queue_size;

--- a/hwpq/hybrid_tree/rtl/src/pipelined_bram_tree.sv
+++ b/hwpq/hybrid_tree/rtl/src/pipelined_bram_tree.sv
@@ -1,3 +1,24 @@
+/*******************************************************************************
+  Module Name: pipelined_bram_tree
+  Date: 2025/03/20
+  Description: A pipelined BRAM-based max-heap tree used as the sub-tree
+               building block of the hybrid_tree architecture. Levels beyond
+               the register-backed top are stored in block RAM, with an index
+               tracking the currently displaced node between levels. Supports
+               enqueue, dequeue, and replace operations.
+  Parameters: QUEUE_SIZE - Maximum number of elements in the sub-tree
+              DATA_WIDTH - Bit width of data elements
+  Inputs: CLK - System clock
+          RSTn - Active-low reset signal
+          i_wrt - Write/insert command (enqueue operation)
+          i_read - Read/pop command (dequeue operation)
+          i_data - Input data to be inserted (or used for replace)
+  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
+           o_empty - High when the queue is empty
+           o_valid - High when o_data holds a valid output
+           o_data - Output data from the highest priority element
+*******************************************************************************/
+
 module pipelined_bram_tree #(
     parameter integer QUEUE_SIZE = 7,
     parameter integer DATA_WIDTH = 16

--- a/hwpq/register_array/rtl/sim/register_array_tb.sv
+++ b/hwpq/register_array/rtl/sim/register_array_tb.sv
@@ -114,6 +114,8 @@ module register_array_tb;
   // Clock generation: 10ns period
   always #5 CLK <= ~CLK;
 
+  int error_count = 0;
+
   initial begin
     // Initialize signals
     CLK = 0;
@@ -144,16 +146,16 @@ module register_array_tb;
       random_value = $urandom_range(1, 1023);
       enqueue(random_value);
     end
-    assert (o_full) else $error("The queue should be filled by the intialization!");
+    assert (o_full) else begin error_count++; $error("The queue should be filled by the intialization!"); end;
 
     // Test Case 1: Dequeue nodes with ENQ_ENA enabled
     $display("\nTest Case 1: Dequeue Test (ENQ_ENA enabled)");
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
       if (!o_empty) begin
-        assert (o_data == ref_queue_enq_1[0]) else $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+        assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
       end else begin
-        assert (o_data == '0) else $error("Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+        assert (o_data == '0) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -162,16 +164,16 @@ module register_array_tb;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       random_value = $urandom_range(1, 1023);
       enqueue(random_value);
-      assert (o_data == ref_queue_enq_1[0]) else $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+      assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
-    assert (o_full) else $error("The queue should be filled after enqueue!");
+    assert (o_full) else begin error_count++; $error("The queue should be filled after enqueue!"); end;
 
     // Test Case 3: Replace nodes with ENQ_ENA enabled
     $display("\nTest Case 3: Replace Test (ENQ_ENA enabled)");
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       random_value = $urandom_range(1, 1023);
       replace(random_value);
-      assert (o_data == ref_queue_enq_1[0]) else $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+      assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
     
     // Test case 4: Random opertaion for 50 times
@@ -182,20 +184,20 @@ module register_array_tb;
         ENQUEUE: begin
           random_value = $urandom_range(1, 1023);
           enqueue(random_value);
-          assert (o_data == ref_queue_enq_1[0]) else $error("Random Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+          assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Random Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
         end
         DEQUEUE: begin
           dequeue();
           if (!o_empty) begin
-            assert (o_data == ref_queue_enq_1[0]) else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+            assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
           end else begin
-            assert (o_data == '0) else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+            assert (o_data == '0) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
         REPLACE: begin
           random_value = $urandom_range(1, 1023);
           replace(random_value);
-          assert (o_data == ref_queue_enq_1[0]) else $error("Random Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+          assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Random Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
         end
       endcase
     end
@@ -227,13 +229,13 @@ module register_array_tb;
 
     // Test Case 5: Dequeue Test with ENQ_ENA disabled
     $display("\nTest Case 5: Dequeue Test (ENQ_ENA disabled)");
-    assert (o_full) else $error("The queue should be filled by the intialization!");
+    assert (o_full) else begin error_count++; $error("The queue should be filled by the intialization!"); end;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
       if (!o_empty) begin
-        assert (o_data == ref_queue_enq_0[0]) else $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+        assert (o_data == ref_queue_enq_0[0]) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
       end else begin
-        assert (o_data == 'd0) else $error("Dequeue: Node value mismatch -> expected %d, got %d", 'd0, o_data);
+        assert (o_data == 'd0) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", 'd0, o_data); end;
       end
     end
     
@@ -244,9 +246,9 @@ module register_array_tb;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       random_value = $urandom_range(1, 1023);
       enqueue(random_value);
-      assert (o_data == ref_queue_enq_0[0]) else $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+      assert (o_data == ref_queue_enq_0[0]) else begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
     end
-    assert (o_data == o_data_prev) else $error("The queue should not have change!");
+    assert (o_data == o_data_prev) else begin error_count++; $error("The queue should not have change!"); end;
     begin
       bit queues_match;
       bit error_flag;
@@ -262,16 +264,16 @@ module register_array_tb;
           end
         end
       end
-      assert (!error_flag) else $error("The queue should not have change!");
+      assert (!error_flag) else begin error_count++; $error("The queue should not have change!"); end;
     end
-    assert (!o_full && !o_empty) else $error("The queue should not do anything!");
+    assert (!o_full && !o_empty) else begin error_count++; $error("The queue should not do anything!"); end;
 
     // Test Case 7: Test Replace operation with ENQ_ENA disabled
     $display("\nTest Case 7: Replace Test (ENQ_ENA disabled)");
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       random_value = $urandom_range(1, 1023);
       replace(random_value);
-      assert (o_data == ref_queue_enq_0[0]) else $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+      assert (o_data == ref_queue_enq_0[0]) else begin error_count++; $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
     end
     
     // Test case 8: Random opertaion for 50 times
@@ -282,21 +284,26 @@ module register_array_tb;
         DEQUEUE: begin
           dequeue();
           if (!o_empty) begin
-            assert (o_data == ref_queue_enq_0[0]) else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+            assert (o_data == ref_queue_enq_0[0]) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
           end else begin
-            assert (o_data == '0) else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+            assert (o_data == '0) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
         REPLACE: begin
           random_value = $urandom_range(1, 1023);
           replace(random_value);
-          assert (o_data == ref_queue_enq_0[0]) else $error("Random Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+          assert (o_data == ref_queue_enq_0[0]) else begin error_count++; $error("Random Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
         end
       endcase
     end
 
-    $display("\nTest completed!");
-    $finish;
+    if (error_count == 0) begin
+      $display("\nTest completed!");
+      $finish;
+    end else begin
+      $display("\n%0d error(s) detected during simulation.", error_count);
+      $fatal(1, "Test FAILED with %0d error(s).", error_count);
+    end
   end
 
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);

--- a/hwpq/register_array/rtl/sim/register_array_tb.sv
+++ b/hwpq/register_array/rtl/sim/register_array_tb.sv
@@ -309,21 +309,27 @@ module register_array_tb;
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     begin
       if (!o_full) begin
-        if (current_mode == ENABLED) begin
-          i_wrt_ena = 1;
-          i_read_ena = 0;
-          i_data_ena = value;
+        case (current_mode)
+          ENABLED: begin
+            i_wrt_ena = 1;
+            i_read_ena = 0;
+            i_data_ena = value;
 
-          ref_queue_enq_1[ref_queue_enq_1_size] = value;
-          ref_queue_enq_1_size++;
-      
-          rsort_ena();
-        end else if (current_mode == DISABLED) begin
-          i_wrt_dis = 1;
-          i_read_dis = 0;
-          i_data_dis = value;
-//          $display("Enqueue attempt with ENQ_ENA disabled - should have no effect");
-        end
+            ref_queue_enq_1[ref_queue_enq_1_size] = value;
+            ref_queue_enq_1_size++;
+
+            rsort_ena();
+          end
+          DISABLED: begin
+            i_wrt_dis = 1;
+            i_read_dis = 0;
+            i_data_dis = value;
+//            $display("Enqueue attempt with ENQ_ENA disabled - should have no effect");
+          end
+          default: begin
+            $display("Enqueue: Invalid mode, skipping enqueue");
+          end
+        endcase
       end else begin
         $display("Enqueue: Queue full, skipping enqueue");
       end
@@ -339,29 +345,33 @@ module register_array_tb;
   task automatic dequeue();
     begin
       if (!o_empty) begin
-        if (current_mode == ENABLED) begin
-          i_wrt_ena  = 0;
-          i_read_ena = 1;
-          i_data_ena = 0;
+        case (current_mode)
+          ENABLED: begin
+            i_wrt_ena  = 0;
+            i_read_ena = 1;
+            i_data_ena = 0;
 
-          for (int i = 0; i < ref_queue_enq_1_size - 1; i++) begin
-            ref_queue_enq_1[i] = ref_queue_enq_1[i+1];
+            for (int i = 0; i < ref_queue_enq_1_size - 1; i++) begin
+              ref_queue_enq_1[i] = ref_queue_enq_1[i+1];
+            end
+            ref_queue_enq_1[ref_queue_enq_1_size-1] = '0;
+            ref_queue_enq_1_size--;
           end
-          ref_queue_enq_1[ref_queue_enq_1_size-1] = '0; 
-          ref_queue_enq_1_size--;
+          DISABLED: begin
+            i_wrt_dis  = 0;
+            i_read_dis = 1;
+            i_data_dis = 0;
 
-        end else if (current_mode == DISABLED) begin
-          i_wrt_dis  = 0;
-          i_read_dis = 1;
-          i_data_dis = 0;
-
-          for (int i = 0; i < ref_queue_enq_0_size - 1; i++) begin
-            ref_queue_enq_0[i] = ref_queue_enq_0[i+1];
+            for (int i = 0; i < ref_queue_enq_0_size - 1; i++) begin
+              ref_queue_enq_0[i] = ref_queue_enq_0[i+1];
+            end
+            ref_queue_enq_0[ref_queue_enq_0_size-1] = '0;
+            ref_queue_enq_0_size--;
           end
-          ref_queue_enq_0[ref_queue_enq_0_size-1] = '0; 
-          ref_queue_enq_0_size--;
-
-        end
+          default: begin
+            $display("Dequeue: Invalid mode, skipping dequeue");
+          end
+        endcase
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
@@ -377,31 +387,37 @@ module register_array_tb;
 
   task automatic replace(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (current_mode == ENABLED) begin
-        i_wrt_ena  = 1;
-        i_read_ena = 1;
-        i_data_ena = value;
-        if (o_empty) begin
-          ref_queue_enq_1[ref_queue_enq_1_size] = value;
-          ref_queue_enq_1_size++;
-          rsort_ena();
-        end else begin
-          ref_queue_enq_1[0] = value;
-          rsort_ena();
+      case (current_mode)
+        ENABLED: begin
+          i_wrt_ena  = 1;
+          i_read_ena = 1;
+          i_data_ena = value;
+          if (o_empty) begin
+            ref_queue_enq_1[ref_queue_enq_1_size] = value;
+            ref_queue_enq_1_size++;
+            rsort_ena();
+          end else begin
+            ref_queue_enq_1[0] = value;
+            rsort_ena();
+          end
         end
-      end else if (current_mode == DISABLED) begin
-        i_wrt_dis  = 1;
-        i_read_dis = 1;
-        i_data_dis = value;
-        if (o_empty) begin
-          ref_queue_enq_0[ref_queue_enq_0_size] = value;
-          ref_queue_enq_0_size++;
-          rsort_dis();
-        end else begin
-          ref_queue_enq_0[0] = value;
-          rsort_dis();
+        DISABLED: begin
+          i_wrt_dis  = 1;
+          i_read_dis = 1;
+          i_data_dis = value;
+          if (o_empty) begin
+            ref_queue_enq_0[ref_queue_enq_0_size] = value;
+            ref_queue_enq_0_size++;
+            rsort_dis();
+          end else begin
+            ref_queue_enq_0[0] = value;
+            rsort_dis();
+          end
         end
-      end
+        default: begin
+          $display("Replace: Invalid mode, skipping replace");
+        end
+      endcase
       @(posedge CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
@@ -414,15 +430,21 @@ module register_array_tb;
 
   task automatic replace_init(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (current_mode == ENABLED) begin
-        i_wrt_ena  = 1;
-        i_read_ena = 1;
-        i_data_ena = value;
-      end else if (current_mode == DISABLED) begin
-        i_wrt_dis  = 1;
-        i_read_dis = 1;
-        i_data_dis = value;
-      end
+      case (current_mode)
+        ENABLED: begin
+          i_wrt_ena  = 1;
+          i_read_ena = 1;
+          i_data_ena = value;
+        end
+        DISABLED: begin
+          i_wrt_dis  = 1;
+          i_read_dis = 1;
+          i_data_dis = value;
+        end
+        default: begin
+          $display("Replace: Invalid mode, skipping replace");
+        end
+      endcase
       @(posedge CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;

--- a/hwpq/register_array/rtl/sim/register_array_tb.sv
+++ b/hwpq/register_array/rtl/sim/register_array_tb.sv
@@ -332,8 +332,7 @@ module register_array_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK); // should have no effects
+      repeat (2) @(posedge CLK);
     end
   endtask
 
@@ -371,8 +370,8 @@ module register_array_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+
+      repeat (2) @(posedge CLK);
     end
   endtask
 
@@ -408,8 +407,8 @@ module register_array_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+
+      repeat (2) @(posedge CLK);
     end
   endtask
 
@@ -429,8 +428,8 @@ module register_array_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+
+      repeat (2) @(posedge CLK);
     end
   endtask
 

--- a/hwpq/register_array/rtl/sim/register_array_tb.sv
+++ b/hwpq/register_array/rtl/sim/register_array_tb.sv
@@ -20,18 +20,18 @@ module register_array_tb;
   logic [DATA_WIDTH-1:0] i_data_dis;
 
   // Output signals - for ENQ_ENA enabled
-  logic                  o_full_ena;
-  logic                  o_empty_ena;
+  logic                  o_write_ready_ena;
+  logic                  o_read_ready_ena;
   logic [DATA_WIDTH-1:0] o_data_ena;
   
   // Output signals - for ENQ_ENA disabled
-  logic                  o_full_dis;
-  logic                  o_empty_dis;
+  logic                  o_write_ready_dis;
+  logic                  o_read_ready_dis;
   logic [DATA_WIDTH-1:0] o_data_dis;
   
   // Current active outputs for testing
-  logic                  o_full;
-  logic                  o_empty;
+  logic                  o_write_ready;
+  logic                  o_read_ready;
   logic [DATA_WIDTH-1:0] o_data;
   logic [DATA_WIDTH-1:0] o_data_prev;
   
@@ -70,8 +70,8 @@ module register_array_tb;
       .i_wrt(i_wrt_ena),
       .i_read(i_read_ena),
       .i_data(i_data_ena),
-      .o_full(o_full_ena),
-      .o_empty(o_empty_ena),
+      .o_write_ready(o_write_ready_ena),
+      .o_read_ready(o_read_ready_ena),
       .o_data(o_data_ena)
   );
   
@@ -86,26 +86,26 @@ module register_array_tb;
       .i_wrt(i_wrt_dis),
       .i_read(i_read_dis),
       .i_data(i_data_dis),
-      .o_full(o_full_dis),
-      .o_empty(o_empty_dis),
+      .o_write_ready(o_write_ready_dis),
+      .o_read_ready(o_read_ready_dis),
       .o_data(o_data_dis)
   );
 
   always_comb begin : output_signal_switch
     case (current_mode)
       ENABLED : begin
-        o_full = o_full_ena;
-        o_empty = o_empty_ena;
+        o_write_ready = o_write_ready_ena;
+        o_read_ready = o_read_ready_ena;
         o_data = o_data_ena;
       end
       DISABLED : begin
-        o_full = o_full_dis;
-        o_empty = o_empty_dis;
+        o_write_ready = o_write_ready_dis;
+        o_read_ready = o_read_ready_dis;
         o_data = o_data_dis;
       end
       default : begin
-        o_full = o_full_dis;
-        o_empty = o_empty_dis;
+        o_write_ready = o_write_ready_dis;
+        o_read_ready = o_read_ready_dis;
         o_data = o_data_dis;
       end
     endcase
@@ -146,13 +146,13 @@ module register_array_tb;
       random_value = $urandom_range(1, 1023);
       enqueue(random_value);
     end
-    assert (o_full) else begin error_count++; $error("The queue should be filled by the intialization!"); end;
+    assert (!o_write_ready) else begin error_count++; $error("The queue should be filled by the intialization!"); end;
 
     // Test Case 1: Dequeue nodes with ENQ_ENA enabled
     $display("\nTest Case 1: Dequeue Test (ENQ_ENA enabled)");
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
       end else begin
         assert (o_data == '0) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
@@ -166,7 +166,7 @@ module register_array_tb;
       enqueue(random_value);
       assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
-    assert (o_full) else begin error_count++; $error("The queue should be filled after enqueue!"); end;
+    assert (!o_write_ready) else begin error_count++; $error("The queue should be filled after enqueue!"); end;
 
     // Test Case 3: Replace nodes with ENQ_ENA enabled
     $display("\nTest Case 3: Replace Test (ENQ_ENA enabled)");
@@ -188,7 +188,7 @@ module register_array_tb;
         end
         DEQUEUE: begin
           dequeue();
-          if (!o_empty) begin
+          if (o_read_ready) begin
             assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
           end else begin
             assert (o_data == '0) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
@@ -229,10 +229,10 @@ module register_array_tb;
 
     // Test Case 5: Dequeue Test with ENQ_ENA disabled
     $display("\nTest Case 5: Dequeue Test (ENQ_ENA disabled)");
-    assert (o_full) else begin error_count++; $error("The queue should be filled by the intialization!"); end;
+    assert (!o_write_ready) else begin error_count++; $error("The queue should be filled by the intialization!"); end;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue_enq_0[0]) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
       end else begin
         assert (o_data == 'd0) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", 'd0, o_data); end;
@@ -266,7 +266,7 @@ module register_array_tb;
       end
       assert (!error_flag) else begin error_count++; $error("The queue should not have change!"); end;
     end
-    assert (!o_full && !o_empty) else begin error_count++; $error("The queue should not do anything!"); end;
+    assert (o_write_ready && o_read_ready) else begin error_count++; $error("The queue should not do anything!"); end;
 
     // Test Case 7: Test Replace operation with ENQ_ENA disabled
     $display("\nTest Case 7: Replace Test (ENQ_ENA disabled)");
@@ -283,7 +283,7 @@ module register_array_tb;
       case (random_operation)
         DEQUEUE: begin
           dequeue();
-          if (!o_empty) begin
+          if (o_read_ready) begin
             assert (o_data == ref_queue_enq_0[0]) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
           end else begin
             assert (o_data == '0) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
@@ -308,7 +308,7 @@ module register_array_tb;
 
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (!o_full) begin
+      if (o_write_ready) begin
         case (current_mode)
           ENABLED: begin
             i_wrt_ena = 1;
@@ -344,7 +344,7 @@ module register_array_tb;
 
   task automatic dequeue();
     begin
-      if (!o_empty) begin
+      if (o_read_ready) begin
         case (current_mode)
           ENABLED: begin
             i_wrt_ena  = 0;
@@ -392,7 +392,7 @@ module register_array_tb;
           i_wrt_ena  = 1;
           i_read_ena = 1;
           i_data_ena = value;
-          if (o_empty) begin
+          if (!o_read_ready) begin
             ref_queue_enq_1[ref_queue_enq_1_size] = value;
             ref_queue_enq_1_size++;
             rsort_ena();
@@ -405,7 +405,7 @@ module register_array_tb;
           i_wrt_dis  = 1;
           i_read_dis = 1;
           i_data_dis = value;
-          if (o_empty) begin
+          if (!o_read_ready) begin
             ref_queue_enq_0[ref_queue_enq_0_size] = value;
             ref_queue_enq_0_size++;
             rsort_dis();

--- a/hwpq/register_array/rtl/sim/register_array_tb.sv
+++ b/hwpq/register_array/rtl/sim/register_array_tb.sv
@@ -6,8 +6,8 @@ module register_array_tb;
   localparam int DATA_WIDTH = 16;
 
   // Clock and reset signals
-  logic                 CLK;
-  logic                 RSTn;
+  logic                 i_CLK;
+  logic                 i_RSTn;
 
   // Input signals - for ENQ_ENA enabled
   logic                  i_wrt_ena;
@@ -65,8 +65,8 @@ module register_array_tb;
       .QUEUE_SIZE(QUEUE_SIZE),
       .DATA_WIDTH(DATA_WIDTH)
   ) u_RegisterArray_ena (
-      .i_CLK(CLK),
-      .i_RSTn(RSTn),
+      .i_CLK(i_CLK),
+      .i_RSTn(i_RSTn),
       .i_wrt(i_wrt_ena),
       .i_read(i_read_ena),
       .i_data(i_data_ena),
@@ -81,8 +81,8 @@ module register_array_tb;
       .QUEUE_SIZE(QUEUE_SIZE),
       .DATA_WIDTH(DATA_WIDTH)
   ) u_RegisterArray_dis (
-      .i_CLK(CLK),
-      .i_RSTn(RSTn),
+      .i_CLK(i_CLK),
+      .i_RSTn(i_RSTn),
       .i_wrt(i_wrt_dis),
       .i_read(i_read_dis),
       .i_data(i_data_dis),
@@ -112,13 +112,13 @@ module register_array_tb;
   end
 
   // Clock generation: 10ns period
-  always #5 CLK <= ~CLK;
+  always #5 i_CLK <= ~i_CLK;
 
   int error_count = 0;
 
   initial begin
     // Initialize signals
-    CLK = 0;
+    i_CLK = 0;
     i_wrt_ena = 0;
     i_read_ena = 0;
     i_data_ena = 0;
@@ -131,10 +131,10 @@ module register_array_tb;
     ref_queue_prev = {};
 
     // Reset the modules
-    RSTn = 0;
-    @(posedge CLK);
-    RSTn = 1;
-    @(posedge CLK);
+    i_RSTn = 0;
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    @(posedge i_CLK);
 
     // Test with ENQ_ENA enabled
     $display("\n=== Testing with ENQ_ENA enabled ===");
@@ -207,10 +207,10 @@ module register_array_tb;
     current_mode = DISABLED;
 
     // Reset the modules
-    RSTn = 0;
-    @(posedge CLK);
-    RSTn = 1;
-    @(posedge CLK);
+    i_RSTn = 0;
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    @(posedge i_CLK);
     
     // Initialize queue inside enqueue disabled module
     $display("\nInitializing enqueue disabled module by replacing into it");
@@ -224,7 +224,7 @@ module register_array_tb;
 
 
 
-    repeat (2) @(posedge CLK);
+    repeat (2) @(posedge i_CLK);
 
 
     // Test Case 5: Dequeue Test with ENQ_ENA disabled
@@ -333,12 +333,12 @@ module register_array_tb;
       end else begin
         $display("Enqueue: Queue full, skipping enqueue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      repeat (2) @(posedge CLK);
+      repeat (2) @(posedge i_CLK);
     end
   endtask
 
@@ -375,13 +375,13 @@ module register_array_tb;
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
 
-      repeat (2) @(posedge CLK);
+      repeat (2) @(posedge i_CLK);
     end
   endtask
 
@@ -418,13 +418,13 @@ module register_array_tb;
           $display("Replace: Invalid mode, skipping replace");
         end
       endcase
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
 
-      repeat (2) @(posedge CLK);
+      repeat (2) @(posedge i_CLK);
     end
   endtask
 
@@ -445,13 +445,13 @@ module register_array_tb;
           $display("Replace: Invalid mode, skipping replace");
         end
       endcase
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
 
-      repeat (2) @(posedge CLK);
+      repeat (2) @(posedge i_CLK);
     end
   endtask
 

--- a/hwpq/register_array/rtl/src/register_array.sv
+++ b/hwpq/register_array/rtl/src/register_array.sv
@@ -1,5 +1,26 @@
 `default_nettype none
 
+/*******************************************************************************
+  Module Name: register_array
+  Date: 2026/06/21
+  Description: A priority queue implementation that stores elements in a flat
+               register array rather than a hierarchical heap. A replace
+               operation overwrites the leftmost entry with the new item,
+               followed by two phases of array-wide compare-and-swap (even-
+               indexed then odd-indexed neighbor pairs) to restore order.
+  Parameters: ENQ_ENA - Enables the enqueue datapath when set
+              QUEUE_SIZE - Maximum number of elements in the priority queue
+              DATA_WIDTH - Bit width of data elements
+  Inputs: i_CLK - System clock
+          i_RSTn - Active-low reset signal
+          i_wrt - Write/insert command (enqueue/replace operation)
+          i_read - Read/pop command (dequeue/replace operation)
+          i_data - Input data to be enqueued (or used for replace)
+  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
+           o_empty - High when the queue is empty
+           o_data - Output data from the highest priority element
+*******************************************************************************/
+
 module register_array #(
     parameter bit ENQ_ENA = 0,  // if user would like to enable enqueue
     parameter int QUEUE_SIZE = 4,  // size of the queue

--- a/hwpq/register_array/rtl/src/register_array.sv
+++ b/hwpq/register_array/rtl/src/register_array.sv
@@ -16,8 +16,8 @@
           i_wrt - Write/insert command (enqueue/replace operation)
           i_read - Read/pop command (dequeue/replace operation)
           i_data - Input data to be enqueued (or used for replace)
-  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
-           o_empty - High when the queue is empty
+  Outputs: o_write_ready - High when the queue has room to accept a write
+           o_read_ready - High when the queue holds data available to read
            o_data - Output data from the highest priority element
 *******************************************************************************/
 
@@ -33,8 +33,8 @@ module register_array #(
     input var  logic                  i_read,   // pop
     input var  logic [DATA_WIDTH-1:0] i_data,   // input data
     // Outputs
-    output var logic                  o_full,   // queue full
-    output var logic                  o_empty,  // queue empty
+    output var logic                  o_write_ready,   // High if the queue can accept a write
+    output var logic                  o_read_ready,  // High if the queue has data to read
     output var logic [DATA_WIDTH-1:0] o_data    // queue head
 );
 
@@ -67,8 +67,8 @@ module register_array #(
   assign replace = (i_wrt && i_read) ? 'b1 : 'b0;
   assign full = (size >= QUEUE_SIZE) ? 'b1 : 'b0;
   assign empty = (size <= '0) ? 'b1 : 'b0;
-  assign o_full = full;
-  assign o_empty = empty;
+  assign o_write_ready = !full;
+  assign o_read_ready = !empty;
   assign o_data = queue[0];
 
   always_ff @(posedge i_CLK or negedge i_RSTn) begin

--- a/hwpq/register_array_pipelined/rtl/sim/register_array_pipelined_tb.sv
+++ b/hwpq/register_array_pipelined/rtl/sim/register_array_pipelined_tb.sv
@@ -379,8 +379,7 @@ module register_array_pipelined_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK); // should have no effects
+      repeat (2) @(posedge CLK);
     end
   endtask
 
@@ -418,8 +417,8 @@ module register_array_pipelined_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+
+      repeat (2) @(posedge CLK);
     end
   endtask
 
@@ -456,8 +455,8 @@ module register_array_pipelined_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+
+      repeat (2) @(posedge CLK);
     end
   endtask
 

--- a/hwpq/register_array_pipelined/rtl/sim/register_array_pipelined_tb.sv
+++ b/hwpq/register_array_pipelined/rtl/sim/register_array_pipelined_tb.sv
@@ -6,8 +6,8 @@ module register_array_pipelined_tb;
   localparam int DATA_WIDTH = 16;
 
   // Clock and reset signals
-  logic                  CLK;
-  logic                  RSTn;
+  logic                  i_CLK;
+  logic                  i_RSTn;
 
   // Input signals - for ENQ_ENA enabled
   logic                  i_wrt_ena;
@@ -68,8 +68,8 @@ module register_array_pipelined_tb;
       .QUEUE_SIZE(QUEUE_SIZE),
       .DATA_WIDTH(DATA_WIDTH)
   ) u_RegisterArray_ena (
-      .i_CLK  (CLK),
-      .i_RSTn (RSTn),
+      .i_CLK  (i_CLK),
+      .i_RSTn (i_RSTn),
       .i_wrt  (i_wrt_ena),
       .i_read (i_read_ena),
       .i_data (i_data_ena),
@@ -84,8 +84,8 @@ module register_array_pipelined_tb;
       .QUEUE_SIZE(QUEUE_SIZE),
       .DATA_WIDTH(DATA_WIDTH)
   ) u_RegisterArray_dis (
-      .i_CLK  (CLK),
-      .i_RSTn (RSTn),
+      .i_CLK  (i_CLK),
+      .i_RSTn (i_RSTn),
       .i_wrt  (i_wrt_dis),
       .i_read (i_read_dis),
       .i_data (i_data_dis),
@@ -115,13 +115,13 @@ module register_array_pipelined_tb;
   end
 
   // Clock generation: 10ns period
-  always #5 CLK <= ~CLK;
+  always #5 i_CLK <= ~i_CLK;
 
   int error_count = 0;
 
   initial begin
     // Initialize signals
-    CLK = 0;
+    i_CLK = 0;
     i_wrt_ena = 0;
     i_read_ena = 0;
     i_data_ena = 0;
@@ -134,10 +134,10 @@ module register_array_pipelined_tb;
     ref_queue_prev = {};
 
     // Reset the modules
-    RSTn = 0;
-    @(posedge CLK);
-    RSTn = 1;
-    @(posedge CLK);
+    i_RSTn = 0;
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    @(posedge i_CLK);
 
     // Test with ENQ_ENA enabled
     $display("\n=== Testing with ENQ_ENA enabled ===");
@@ -237,10 +237,10 @@ module register_array_pipelined_tb;
     current_mode = DISABLED;
 
     // Reset the modules
-    RSTn = 0;
-    @(posedge CLK);
-    RSTn = 1;
-    @(posedge CLK);
+    i_RSTn = 0;
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    @(posedge i_CLK);
 
     // Initialize queue inside enqueue disabled module
     $display("\nInitializing enqueue disabled module by replacing into it");
@@ -380,12 +380,12 @@ module register_array_pipelined_tb;
       end else begin
         $display("Enqueue: Queue full, skipping enqueue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      repeat (2) @(posedge CLK);
+      repeat (2) @(posedge i_CLK);
     end
   endtask
 
@@ -422,13 +422,13 @@ module register_array_pipelined_tb;
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
 
-      repeat (2) @(posedge CLK);
+      repeat (2) @(posedge i_CLK);
     end
   endtask
 
@@ -466,13 +466,13 @@ module register_array_pipelined_tb;
           $display("Replace: Invalid mode, skipping replace");
         end
       endcase
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
 
-      repeat (2) @(posedge CLK);
+      repeat (2) @(posedge i_CLK);
     end
   endtask
 
@@ -493,13 +493,13 @@ module register_array_pipelined_tb;
           $display("Replace: Invalid mode, skipping replace");
         end
       endcase
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
 
-      @(posedge CLK);
+      @(posedge i_CLK);
     end
   endtask
 

--- a/hwpq/register_array_pipelined/rtl/sim/register_array_pipelined_tb.sv
+++ b/hwpq/register_array_pipelined/rtl/sim/register_array_pipelined_tb.sv
@@ -117,6 +117,8 @@ module register_array_pipelined_tb;
   // Clock generation: 10ns period
   always #5 CLK <= ~CLK;
 
+  int error_count = 0;
+
   initial begin
     // Initialize signals
     CLK = 0;
@@ -147,7 +149,7 @@ module register_array_pipelined_tb;
       enqueue(random_value);
     end
     assert (o_full)
-    else $error("The queue should be filled by the intialization!");
+    else begin error_count++; $error("The queue should be filled by the intialization!"); end;
 
     // Test Case 1: Dequeue nodes with ENQ_ENA enabled
     $display("\nTest Case 1: Dequeue Test (ENQ_ENA enabled)");
@@ -156,10 +158,10 @@ module register_array_pipelined_tb;
       if (!o_empty) begin
         assert (o_data == ref_queue_enq_1[0])
         else
-          $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+          begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
       end else begin
         assert (o_data == '0)
-        else $error("Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+        else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -170,10 +172,10 @@ module register_array_pipelined_tb;
       enqueue(random_value);
       assert (o_data == ref_queue_enq_1[0])
       else
-        $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+        begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
     assert (o_full)
-    else $error("The queue should be filled after enqueue!");
+    else begin error_count++; $error("The queue should be filled after enqueue!"); end;
 
     // Test Case 3: Replace nodes with ENQ_ENA enabled
     $display("\nTest Case 3: Replace Test (ENQ_ENA enabled)");
@@ -182,7 +184,7 @@ module register_array_pipelined_tb;
       replace(random_value);
       assert (o_data == ref_queue_enq_1[0])
       else
-        $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+        begin error_count++; $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
 
     // Test case 4: Random opertaion for 50 times
@@ -195,25 +197,25 @@ module register_array_pipelined_tb;
           enqueue(random_value);
           assert (o_data == ref_queue_enq_1[0])
           else
-            $error(
+            begin error_count++; $error(
                 "Random Enqueue: Node value mismatch -> expected %d, got %d",
                 ref_queue_enq_1[0],
                 o_data
-            );
+            ); end;
         end
         DEQUEUE: begin
           dequeue();
           if (!o_empty) begin
             assert (o_data == ref_queue_enq_1[0])
             else
-              $error(
+              begin error_count++; $error(
                   "Random Dequeue: Node value mismatch -> expected %d, got %d",
                   ref_queue_enq_1[0],
                   o_data
-              );
+              ); end;
           end else begin
             assert (o_data == '0)
-            else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+            else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
         REPLACE: begin
@@ -221,11 +223,11 @@ module register_array_pipelined_tb;
           replace(random_value);
           assert (o_data == ref_queue_enq_1[0])
           else
-            $error(
+            begin error_count++; $error(
                 "Random Replace: Node value mismatch -> expected %d, got %d",
                 ref_queue_enq_1[0],
                 o_data
-            );
+            ); end;
         end
       endcase
     end
@@ -252,16 +254,16 @@ module register_array_pipelined_tb;
 
     // Test Case 5: Dequeue Test with ENQ_ENA disabled
     $display("\nTest Case 5: Dequeue Test (ENQ_ENA disabled)");
-    assert (o_full) else $error("The queue should be filled by the intialization!");
+    assert (o_full) else begin error_count++; $error("The queue should be filled by the intialization!"); end;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue_enq_0[0])
         else
-          $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+          begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
       end else begin
         assert (o_data == 'd0)
-        else $error("Dequeue: Node value mismatch -> expected %d, got %d", 'd0, o_data);
+        else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", 'd0, o_data); end;
       end
     end
 
@@ -274,10 +276,10 @@ module register_array_pipelined_tb;
       enqueue(random_value);
       assert (o_data == ref_queue_enq_0[0])
       else
-        $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+        begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
     end
     assert (o_data == o_data_prev)
-    else $error("The queue should not have change!");
+    else begin error_count++; $error("The queue should not have change!"); end;
     begin
       bit queues_match;
       bit error_flag;
@@ -293,10 +295,10 @@ module register_array_pipelined_tb;
           end
         end
       end
-      assert (!error_flag) else $error("The queue should not have change!");
+      assert (!error_flag) else begin error_count++; $error("The queue should not have change!"); end;
     end
     assert (!o_full && !o_empty)
-    else $error("The queue should not do anything!");
+    else begin error_count++; $error("The queue should not do anything!"); end;
 
     // Test Case 7: Test Replace operation with ENQ_ENA disabled
     $display("\nTest Case 7: Replace Test (ENQ_ENA disabled)");
@@ -305,7 +307,7 @@ module register_array_pipelined_tb;
       replace(random_value);
       assert (o_data == ref_queue_enq_0[0])
       else
-        $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+        begin error_count++; $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
     end
 
     // Test case 8: Random opertaion for 50 times
@@ -318,14 +320,14 @@ module register_array_pipelined_tb;
           if (!o_empty) begin
             assert (o_data == ref_queue_enq_0[0])
             else
-              $error(
+              begin error_count++; $error(
                   "Random Dequeue: Node value mismatch -> expected %d, got %d",
                   ref_queue_enq_0[0],
                   o_data
-              );
+              ); end;
           end else begin
             assert (o_data == '0)
-            else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+            else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
         REPLACE: begin
@@ -333,17 +335,22 @@ module register_array_pipelined_tb;
           replace(random_value);
           assert (o_data == ref_queue_enq_0[0])
           else
-            $error(
+            begin error_count++; $error(
                 "Random Replace: Node value mismatch -> expected %d, got %d",
                 ref_queue_enq_0[0],
                 o_data
-            );
+            ); end;
         end
       endcase
     end
 
-    $display("\nTest completed!");
-    $finish;
+    if (error_count == 0) begin
+      $display("\nTest completed!");
+      $finish;
+    end else begin
+      $display("\n%0d error(s) detected during simulation.", error_count);
+      $fatal(1, "Test FAILED with %0d error(s).", error_count);
+    end
   end
 
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);

--- a/hwpq/register_array_pipelined/rtl/sim/register_array_pipelined_tb.sv
+++ b/hwpq/register_array_pipelined/rtl/sim/register_array_pipelined_tb.sv
@@ -20,18 +20,18 @@ module register_array_pipelined_tb;
   logic [DATA_WIDTH-1:0] i_data_dis;
 
   // Output signals - for ENQ_ENA enabled
-  logic                  o_full_ena;
-  logic                  o_empty_ena;
+  logic                  o_write_ready_ena;
+  logic                  o_read_ready_ena;
   logic [DATA_WIDTH-1:0] o_data_ena;
 
   // Output signals - for ENQ_ENA disabled
-  logic                  o_full_dis;
-  logic                  o_empty_dis;
+  logic                  o_write_ready_dis;
+  logic                  o_read_ready_dis;
   logic [DATA_WIDTH-1:0] o_data_dis;
 
   // Current active outputs for testing
-  logic                  o_full;
-  logic                  o_empty;
+  logic                  o_write_ready;
+  logic                  o_read_ready;
   logic [DATA_WIDTH-1:0] o_data;
   logic [DATA_WIDTH-1:0] o_data_prev;
 
@@ -73,8 +73,8 @@ module register_array_pipelined_tb;
       .i_wrt  (i_wrt_ena),
       .i_read (i_read_ena),
       .i_data (i_data_ena),
-      .o_full (o_full_ena),
-      .o_empty(o_empty_ena),
+      .o_write_ready (o_write_ready_ena),
+      .o_read_ready(o_read_ready_ena),
       .o_data (o_data_ena)
   );
 
@@ -89,26 +89,26 @@ module register_array_pipelined_tb;
       .i_wrt  (i_wrt_dis),
       .i_read (i_read_dis),
       .i_data (i_data_dis),
-      .o_full (o_full_dis),
-      .o_empty(o_empty_dis),
+      .o_write_ready (o_write_ready_dis),
+      .o_read_ready(o_read_ready_dis),
       .o_data (o_data_dis)
   );
 
   always_comb begin : output_signal_switch
     case (current_mode)
       ENABLED: begin
-        o_full  = o_full_ena;
-        o_empty = o_empty_ena;
+        o_write_ready  = o_write_ready_ena;
+        o_read_ready = o_read_ready_ena;
         o_data  = o_data_ena;
       end
       DISABLED: begin
-        o_full  = o_full_dis;
-        o_empty = o_empty_dis;
+        o_write_ready  = o_write_ready_dis;
+        o_read_ready = o_read_ready_dis;
         o_data  = o_data_dis;
       end
       default: begin
-        o_full  = o_full_dis;
-        o_empty = o_empty_dis;
+        o_write_ready  = o_write_ready_dis;
+        o_read_ready = o_read_ready_dis;
         o_data  = o_data_dis;
       end
     endcase
@@ -148,14 +148,14 @@ module register_array_pipelined_tb;
       random_value = DATA_WIDTH'(($urandom & ((1 << DATA_WIDTH) - 1)) % 1025);
       enqueue(random_value);
     end
-    assert (o_full)
+    assert (!o_write_ready)
     else begin error_count++; $error("The queue should be filled by the intialization!"); end;
 
     // Test Case 1: Dequeue nodes with ENQ_ENA enabled
     $display("\nTest Case 1: Dequeue Test (ENQ_ENA enabled)");
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue_enq_1[0])
         else
           begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
@@ -174,7 +174,7 @@ module register_array_pipelined_tb;
       else
         begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
-    assert (o_full)
+    assert (!o_write_ready)
     else begin error_count++; $error("The queue should be filled after enqueue!"); end;
 
     // Test Case 3: Replace nodes with ENQ_ENA enabled
@@ -205,7 +205,7 @@ module register_array_pipelined_tb;
         end
         DEQUEUE: begin
           dequeue();
-          if (!o_empty) begin
+          if (o_read_ready) begin
             assert (o_data == ref_queue_enq_1[0])
             else
               begin error_count++; $error(
@@ -254,10 +254,10 @@ module register_array_pipelined_tb;
 
     // Test Case 5: Dequeue Test with ENQ_ENA disabled
     $display("\nTest Case 5: Dequeue Test (ENQ_ENA disabled)");
-    assert (o_full) else begin error_count++; $error("The queue should be filled by the intialization!"); end;
+    assert (!o_write_ready) else begin error_count++; $error("The queue should be filled by the intialization!"); end;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue_enq_0[0])
         else
           begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
@@ -297,7 +297,7 @@ module register_array_pipelined_tb;
       end
       assert (!error_flag) else begin error_count++; $error("The queue should not have change!"); end;
     end
-    assert (!o_full && !o_empty)
+    assert (o_write_ready && o_read_ready)
     else begin error_count++; $error("The queue should not do anything!"); end;
 
     // Test Case 7: Test Replace operation with ENQ_ENA disabled
@@ -317,7 +317,7 @@ module register_array_pipelined_tb;
       case (random_operation)
         DEQUEUE: begin
           dequeue();
-          if (!o_empty) begin
+          if (o_read_ready) begin
             assert (o_data == ref_queue_enq_0[0])
             else
               begin error_count++; $error(
@@ -355,7 +355,7 @@ module register_array_pipelined_tb;
 
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (!o_full) begin
+      if (o_write_ready) begin
         case (current_mode)
           ENABLED: begin
             i_wrt_ena = 1;
@@ -391,7 +391,7 @@ module register_array_pipelined_tb;
 
   task automatic dequeue();
     begin
-      if (!o_empty) begin
+      if (o_read_ready) begin
         case (current_mode)
           ENABLED: begin
             i_wrt_ena  = 0;
@@ -439,7 +439,7 @@ module register_array_pipelined_tb;
           i_wrt_ena  = 1;
           i_read_ena = 1;
           i_data_ena = value;
-          if (o_empty) begin
+          if (!o_read_ready) begin
             ref_queue_enq_1[ref_queue_enq_1_size] = value;
             ref_queue_enq_1_size++;
 
@@ -453,7 +453,7 @@ module register_array_pipelined_tb;
           i_wrt_dis  = 1;
           i_read_dis = 1;
           i_data_dis = value;
-          if (o_empty) begin
+          if (!o_read_ready) begin
             ref_queue_enq_0[ref_queue_enq_0_size] = value;
             ref_queue_enq_0_size++;
             rsort_dis();

--- a/hwpq/register_array_pipelined/rtl/sim/register_array_pipelined_tb.sv
+++ b/hwpq/register_array_pipelined/rtl/sim/register_array_pipelined_tb.sv
@@ -356,21 +356,27 @@ module register_array_pipelined_tb;
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     begin
       if (!o_full) begin
-        if (current_mode == ENABLED) begin
-          i_wrt_ena = 1;
-          i_read_ena = 0;
-          i_data_ena = value;
+        case (current_mode)
+          ENABLED: begin
+            i_wrt_ena = 1;
+            i_read_ena = 0;
+            i_data_ena = value;
 
-          ref_queue_enq_1[ref_queue_enq_1_size] = value;
-          ref_queue_enq_1_size++;
-      
-          rsort_ena();
-        end else if (current_mode == DISABLED) begin
-          i_wrt_dis = 1;
-          i_read_dis = 0;
-          i_data_dis = value;
-//          $display("Enqueue attempt with ENQ_ENA disabled - should have no effect");
-        end
+            ref_queue_enq_1[ref_queue_enq_1_size] = value;
+            ref_queue_enq_1_size++;
+
+            rsort_ena();
+          end
+          DISABLED: begin
+            i_wrt_dis = 1;
+            i_read_dis = 0;
+            i_data_dis = value;
+//            $display("Enqueue attempt with ENQ_ENA disabled - should have no effect");
+          end
+          default: begin
+            $display("Enqueue: Invalid mode, skipping enqueue");
+          end
+        endcase
       end else begin
         $display("Enqueue: Queue full, skipping enqueue");
       end
@@ -386,29 +392,33 @@ module register_array_pipelined_tb;
   task automatic dequeue();
     begin
       if (!o_empty) begin
-        if (current_mode == ENABLED) begin
-          i_wrt_ena  = 0;
-          i_read_ena = 1;
-          i_data_ena = 0;
+        case (current_mode)
+          ENABLED: begin
+            i_wrt_ena  = 0;
+            i_read_ena = 1;
+            i_data_ena = 0;
 
-          for (int i = 0; i < ref_queue_enq_1_size - 1; i++) begin
-            ref_queue_enq_1[i] = ref_queue_enq_1[i+1];
+            for (int i = 0; i < ref_queue_enq_1_size - 1; i++) begin
+              ref_queue_enq_1[i] = ref_queue_enq_1[i+1];
+            end
+            ref_queue_enq_1[ref_queue_enq_1_size-1] = '0;
+            ref_queue_enq_1_size--;
           end
-          ref_queue_enq_1[ref_queue_enq_1_size-1] = '0; 
-          ref_queue_enq_1_size--;
+          DISABLED: begin
+            i_wrt_dis  = 0;
+            i_read_dis = 1;
+            i_data_dis = 0;
 
-        end else if (current_mode == DISABLED) begin
-          i_wrt_dis  = 0;
-          i_read_dis = 1;
-          i_data_dis = 0;
-
-          for (int i = 0; i < ref_queue_enq_0_size - 1; i++) begin
-            ref_queue_enq_0[i] = ref_queue_enq_0[i+1];
+            for (int i = 0; i < ref_queue_enq_0_size - 1; i++) begin
+              ref_queue_enq_0[i] = ref_queue_enq_0[i+1];
+            end
+            ref_queue_enq_0[ref_queue_enq_0_size-1] = '0;
+            ref_queue_enq_0_size--;
           end
-          ref_queue_enq_0[ref_queue_enq_0_size-1] = '0; 
-          ref_queue_enq_0_size--;
-
-        end
+          default: begin
+            $display("Dequeue: Invalid mode, skipping dequeue");
+          end
+        endcase
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
@@ -424,32 +434,38 @@ module register_array_pipelined_tb;
 
   task automatic replace(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (current_mode == ENABLED) begin
-        i_wrt_ena  = 1;
-        i_read_ena = 1;
-        i_data_ena = value;
-        if (o_empty) begin
-          ref_queue_enq_1[ref_queue_enq_1_size] = value;
-          ref_queue_enq_1_size++;
-          
-          rsort_ena();
-        end else begin
-          ref_queue_enq_1[0] = value;
-          rsort_ena();
+      case (current_mode)
+        ENABLED: begin
+          i_wrt_ena  = 1;
+          i_read_ena = 1;
+          i_data_ena = value;
+          if (o_empty) begin
+            ref_queue_enq_1[ref_queue_enq_1_size] = value;
+            ref_queue_enq_1_size++;
+
+            rsort_ena();
+          end else begin
+            ref_queue_enq_1[0] = value;
+            rsort_ena();
+          end
         end
-      end else if (current_mode == DISABLED) begin
-        i_wrt_dis  = 1;
-        i_read_dis = 1;
-        i_data_dis = value;
-        if (o_empty) begin
-          ref_queue_enq_0[ref_queue_enq_0_size] = value;
-          ref_queue_enq_0_size++;
-          rsort_dis();
-        end else begin
-          ref_queue_enq_0[0] = value;
-          rsort_dis();
+        DISABLED: begin
+          i_wrt_dis  = 1;
+          i_read_dis = 1;
+          i_data_dis = value;
+          if (o_empty) begin
+            ref_queue_enq_0[ref_queue_enq_0_size] = value;
+            ref_queue_enq_0_size++;
+            rsort_dis();
+          end else begin
+            ref_queue_enq_0[0] = value;
+            rsort_dis();
+          end
         end
-      end
+        default: begin
+          $display("Replace: Invalid mode, skipping replace");
+        end
+      endcase
       @(posedge CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
@@ -462,22 +478,28 @@ module register_array_pipelined_tb;
 
   task automatic replace_init(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (current_mode == ENABLED) begin
-        i_wrt_ena  = 1;
-        i_read_ena = 1;
-        i_data_ena = value;
-      end else if (current_mode == DISABLED) begin
-        i_wrt_dis  = 1;
-        i_read_dis = 1;
-        i_data_dis = value;
-      end
+      case (current_mode)
+        ENABLED: begin
+          i_wrt_ena  = 1;
+          i_read_ena = 1;
+          i_data_ena = value;
+        end
+        DISABLED: begin
+          i_wrt_dis  = 1;
+          i_read_dis = 1;
+          i_data_dis = value;
+        end
+        default: begin
+          $display("Replace: Invalid mode, skipping replace");
+        end
+      endcase
       @(posedge CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) @(posedge CLK);
-      else if (current_mode == DISABLED) @(posedge CLK);
+
+      @(posedge CLK);
     end
   endtask
 

--- a/hwpq/register_array_pipelined/rtl/src/register_array_pipelined.sv
+++ b/hwpq/register_array_pipelined/rtl/src/register_array_pipelined.sv
@@ -1,5 +1,26 @@
 `default_nettype none
 
+/*******************************************************************************
+  Module Name: register_array_pipelined
+  Date: 2026/06/21
+  Description: A pipelined version of the register array priority queue that
+               splits the array-wide compare-and-swap operation across two
+               clock cycles (even-indexed pairs, then odd-indexed pairs) to
+               shorten the combinational path and reach higher clock
+               frequencies.
+  Parameters: ENQ_ENA - Enables the enqueue datapath when set
+              QUEUE_SIZE - Maximum number of elements in the priority queue
+              DATA_WIDTH - Bit width of data elements
+  Inputs: i_CLK - System clock
+          i_RSTn - Active-low reset signal
+          i_wrt - Write/insert command (enqueue/replace operation)
+          i_read - Read/pop command (dequeue/replace operation)
+          i_data - Input data to be enqueued (or used for replace)
+  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
+           o_empty - High when the queue is empty
+           o_data - Output data from the highest priority element
+*******************************************************************************/
+
 module register_array_pipelined #(
     parameter bit ENQ_ENA = 1,  // if user would like to enable enqueue
     parameter int QUEUE_SIZE = 4,  // size of the queue

--- a/hwpq/register_array_pipelined/rtl/src/register_array_pipelined.sv
+++ b/hwpq/register_array_pipelined/rtl/src/register_array_pipelined.sv
@@ -16,8 +16,8 @@
           i_wrt - Write/insert command (enqueue/replace operation)
           i_read - Read/pop command (dequeue/replace operation)
           i_data - Input data to be enqueued (or used for replace)
-  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
-           o_empty - High when the queue is empty
+  Outputs: o_write_ready - High when the queue has room to accept a write
+           o_read_ready - High when the queue holds data available to read
            o_data - Output data from the highest priority element
 *******************************************************************************/
 
@@ -33,8 +33,8 @@ module register_array_pipelined #(
     input var  logic                  i_read,   // pop
     input var  logic [DATA_WIDTH-1:0] i_data,   // input data
     // Outputs
-    output var logic                  o_full,   // queue full
-    output var logic                  o_empty,  // queue empty
+    output var logic                  o_write_ready,   // High if the queue can accept a write
+    output var logic                  o_read_ready,  // High if the queue has data to read
     output var logic [DATA_WIDTH-1:0] o_data    // queue head
 );
 
@@ -67,8 +67,8 @@ module register_array_pipelined #(
   assign replace = (i_wrt && i_read) ? 'b1 : 'b0;
   assign full = (size >= QUEUE_SIZE) ? 'b1 : 'b0;
   assign empty = (size <= '0) ? 'b1 : 'b0;
-  assign o_full = full;
-  assign o_empty = empty;
+  assign o_write_ready = !full;
+  assign o_read_ready = !empty;
   assign o_data = queue[0];
 
   always_ff @(posedge i_CLK or negedge i_RSTn) begin

--- a/hwpq/register_tree/rtl/sim/register_tree_tb.sv
+++ b/hwpq/register_tree/rtl/sim/register_tree_tb.sv
@@ -114,6 +114,8 @@ module register_tree_tb;
   // Clock generation: 10ns period
   always #5 CLK <= ~CLK;
 
+  int error_count = 0;
+
   initial begin
     // Initialize signals
     CLK = 0;
@@ -143,16 +145,16 @@ module register_tree_tb;
       random_value = $urandom_range(1, 1023);
       enqueue(random_value);
     end
-    assert (o_full) else $error("The queue should be filled by the intialization!");
+    assert (o_full) else begin error_count++; $error("The queue should be filled by the intialization!"); end;
 
     // Test Case 1: Dequeue nodes with ENQ_ENA enabled
     $display("\nTest Case 1: Dequeue Test (ENQ_ENA enabled)");
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
       if (!o_empty) begin
-        assert (o_data == ref_queue_enq_1[0]) else $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+        assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
       end else begin
-        assert (o_data == '0) else $error("Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+        assert (o_data == '0) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -161,16 +163,16 @@ module register_tree_tb;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       random_value = $urandom_range(1, 1023);
       enqueue(random_value);
-      assert (o_data == ref_queue_enq_1[0]) else $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+      assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
-    assert (o_full) else $error("The queue should be filled after enqueue!");
+    assert (o_full) else begin error_count++; $error("The queue should be filled after enqueue!"); end;
 
     // Test Case 3: Replace nodes with ENQ_ENA enabled
     $display("\nTest Case 3: Replace Test (ENQ_ENA enabled)");
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       random_value = $urandom_range(1, 1023);
       replace(random_value);
-      assert (o_data == ref_queue_enq_1[0]) else $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+      assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
 
     // Test case 4: Random opertaion for 50 times
@@ -181,20 +183,20 @@ module register_tree_tb;
         ENQUEUE: begin
           random_value = $urandom_range(1, 1023);
           enqueue(random_value);
-          assert (o_data == ref_queue_enq_1[0]) else $error("Random Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+          assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Random Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
         end
         DEQUEUE: begin
           dequeue();
           if (!o_empty) begin
-            assert (o_data == ref_queue_enq_1[0]) else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+            assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
           end else begin
-            assert (o_data == '0) else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+            assert (o_data == '0) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
         REPLACE: begin
           random_value = $urandom_range(1, 1023);
           replace(random_value);
-          assert (o_data == ref_queue_enq_1[0]) else $error("Random Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+          assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Random Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
         end
       endcase
     end
@@ -224,16 +226,16 @@ module register_tree_tb;
     // Test Case 4: Dequeue Test with ENQ_ENA disabled
     $display("\nTest Case 4: Dequeue Test (ENQ_ENA disabled)");
     assert (o_full)
-    else $error("The queue should be filled by the intialization!");
+    else begin error_count++; $error("The queue should be filled by the intialization!"); end;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue_enq_0[0])
         else
-          $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+          begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
       end else begin
         assert (o_data == 'd0)
-        else $error("Dequeue: Node value mismatch -> expected %d, got %d", 'd0, o_data);
+        else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", 'd0, o_data); end;
       end
     end
 
@@ -246,9 +248,9 @@ module register_tree_tb;
       enqueue(random_value);
       assert (o_data == ref_queue_enq_0[0])
       else
-        $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+        begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
     end
-    assert (o_data == o_data_prev) else $error("The queue should not have change!");
+    assert (o_data == o_data_prev) else begin error_count++; $error("The queue should not have change!"); end;
     begin
       bit queues_match;
       bit error_flag;
@@ -264,9 +266,9 @@ module register_tree_tb;
           end
         end
       end
-      assert (!error_flag) else $error("The queue should not have change!");
+      assert (!error_flag) else begin error_count++; $error("The queue should not have change!"); end;
     end
-    assert (!o_full && !o_empty) else $error("The queue should not do anything!");
+    assert (!o_full && !o_empty) else begin error_count++; $error("The queue should not do anything!"); end;
 
     // Test Case 6: Test Replace operation with ENQ_ENA disabled
     $display("\nTest Case 6: Replace Test (ENQ_ENA disabled)");
@@ -275,7 +277,7 @@ module register_tree_tb;
       replace(random_value);
       assert (o_data == ref_queue_enq_0[0])
       else
-        $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+        begin error_count++; $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
     end
 
     // Test case 8: Random opertaion for 50 times
@@ -288,14 +290,14 @@ module register_tree_tb;
           if (!o_empty) begin
             assert (o_data == ref_queue_enq_0[0])
             else
-              $error(
+              begin error_count++; $error(
                   "Random Dequeue: Node value mismatch -> expected %d, got %d",
                   ref_queue_enq_0[0],
                   o_data
-              );
+              ); end;
           end else begin
             assert (o_data == '0)
-            else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+            else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
         REPLACE: begin
@@ -303,17 +305,22 @@ module register_tree_tb;
           replace(random_value);
           assert (o_data == ref_queue_enq_0[0])
           else
-            $error(
+            begin error_count++; $error(
                 "Random Replace: Node value mismatch -> expected %d, got %d",
                 ref_queue_enq_0[0],
                 o_data
-            );
+            ); end;
         end
       endcase
     end
 
-    $display("\nTest completed!");
-    $finish;
+    if (error_count == 0) begin
+      $display("\nTest completed!");
+      $finish;
+    end else begin
+      $display("\n%0d error(s) detected during simulation.", error_count);
+      $fatal(1, "Test FAILED with %0d error(s).", error_count);
+    end
   end
 
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);

--- a/hwpq/register_tree/rtl/sim/register_tree_tb.sv
+++ b/hwpq/register_tree/rtl/sim/register_tree_tb.sv
@@ -6,8 +6,8 @@ module register_tree_tb;
   localparam int DATA_WIDTH = 16;
 
   // Clock and reset signals
-  logic                 CLK;
-  logic                 RSTn;
+  logic                 i_CLK;
+  logic                 i_RSTn;
 
   // Input signals - for ENQ_ENA enabled
   logic                  i_wrt_ena;
@@ -65,8 +65,8 @@ module register_tree_tb;
       .QUEUE_SIZE(QUEUE_SIZE),
       .DATA_WIDTH(DATA_WIDTH)
   ) u_RegisterTree_ena (
-      .i_CLK(CLK),
-      .i_RSTn(RSTn),
+      .i_CLK(i_CLK),
+      .i_RSTn(i_RSTn),
       .i_wrt(i_wrt_ena),
       .i_read(i_read_ena),
       .i_data(i_data_ena),
@@ -81,8 +81,8 @@ module register_tree_tb;
       .QUEUE_SIZE(QUEUE_SIZE),
       .DATA_WIDTH(DATA_WIDTH)
   ) u_RegisterTree_dis (
-      .i_CLK(CLK),
-      .i_RSTn(RSTn),
+      .i_CLK(i_CLK),
+      .i_RSTn(i_RSTn),
       .i_wrt(i_wrt_dis),
       .i_read(i_read_dis),
       .i_data(i_data_dis),
@@ -112,13 +112,13 @@ module register_tree_tb;
   end
 
   // Clock generation: 10ns period
-  always #5 CLK <= ~CLK;
+  always #5 i_CLK <= ~i_CLK;
 
   int error_count = 0;
 
   initial begin
     // Initialize signals
-    CLK = 0;
+    i_CLK = 0;
     i_wrt_ena = 0;
     i_read_ena = 0;
     i_data_ena = 0;
@@ -131,10 +131,10 @@ module register_tree_tb;
     ref_queue_prev = {};
 
     // Reset the modules
-    RSTn = 0;
-    @(posedge CLK);
-    RSTn = 1;
-    @(posedge CLK);
+    i_RSTn = 0;
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    @(posedge i_CLK);
 
     // Test with ENQ_ENA enabled
     $display("\n=== Testing with ENQ_ENA enabled ===");
@@ -206,10 +206,10 @@ module register_tree_tb;
     $display("\n=== Testing with ENQ_ENA disabled ===");
     current_mode = DISABLED;
 
-    RSTn = 0;
-    @(posedge CLK);
-    RSTn = 1;
-    @(posedge CLK);
+    i_RSTn = 0;
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    @(posedge i_CLK);
 
     // Initialize queue inside enqueue disabled module
     $display("\nInitializing enqueue disabled module by replacing into it");
@@ -221,7 +221,7 @@ module register_tree_tb;
     end
     rsort_dis();
 
-    repeat (4) @(posedge CLK);
+    repeat (4) @(posedge i_CLK);
 
     // Test Case 4: Dequeue Test with ENQ_ENA disabled
     $display("\nTest Case 4: Dequeue Test (ENQ_ENA disabled)");
@@ -349,17 +349,17 @@ module register_tree_tb;
       end else begin
         $display("Enqueue: Queue full, skipping enqueue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
       case (current_mode)
         ENABLED: begin
-          repeat ($clog2(QUEUE_SIZE)) @(posedge CLK);
+          repeat ($clog2(QUEUE_SIZE)) @(posedge i_CLK);
         end
         DISABLED: begin
-          repeat (2) @(posedge CLK); // should have no effects
+          repeat (2) @(posedge i_CLK); // should have no effects
         end
         default: begin
           $display("Enqueue: Invalid mode, skipping enqueue");
@@ -400,13 +400,13 @@ module register_tree_tb;
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
       
-      repeat (2) @(posedge CLK);
+      repeat (2) @(posedge i_CLK);
     end
   endtask
 
@@ -441,12 +441,12 @@ module register_tree_tb;
         end
       end
       endcase
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      repeat (2) @(posedge CLK); 
+      repeat (2) @(posedge i_CLK); 
     end  
   endtask
 
@@ -464,12 +464,12 @@ module register_tree_tb;
           i_data_dis = value;
         end
       endcase
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      repeat (2) @(posedge CLK);
+      repeat (2) @(posedge i_CLK);
     end
   endtask
 

--- a/hwpq/register_tree/rtl/sim/register_tree_tb.sv
+++ b/hwpq/register_tree/rtl/sim/register_tree_tb.sv
@@ -20,18 +20,18 @@ module register_tree_tb;
   logic [DATA_WIDTH-1:0] i_data_dis;
 
   // Output signals - for ENQ_ENA enabled
-  logic                  o_full_ena;
-  logic                  o_empty_ena;
+  logic                  o_write_ready_ena;
+  logic                  o_read_ready_ena;
   logic [DATA_WIDTH-1:0] o_data_ena;
   
   // Output signals - for ENQ_ENA disabled
-  logic                  o_full_dis;
-  logic                  o_empty_dis;
+  logic                  o_write_ready_dis;
+  logic                  o_read_ready_dis;
   logic [DATA_WIDTH-1:0] o_data_dis;
   
   // Current active outputs for testing
-  logic                  o_full;
-  logic                  o_empty;
+  logic                  o_write_ready;
+  logic                  o_read_ready;
   logic [DATA_WIDTH-1:0] o_data;
   logic [DATA_WIDTH-1:0] o_data_prev;
   
@@ -70,8 +70,8 @@ module register_tree_tb;
       .i_wrt(i_wrt_ena),
       .i_read(i_read_ena),
       .i_data(i_data_ena),
-      .o_full(o_full_ena),
-      .o_empty(o_empty_ena),
+      .o_write_ready(o_write_ready_ena),
+      .o_read_ready(o_read_ready_ena),
       .o_data(o_data_ena)
   );
   
@@ -86,26 +86,26 @@ module register_tree_tb;
       .i_wrt(i_wrt_dis),
       .i_read(i_read_dis),
       .i_data(i_data_dis),
-      .o_full(o_full_dis),
-      .o_empty(o_empty_dis),
+      .o_write_ready(o_write_ready_dis),
+      .o_read_ready(o_read_ready_dis),
       .o_data(o_data_dis)
   );
 
   always_comb begin : output_signal_switch
     case (current_mode)
       ENABLED : begin
-        o_full = o_full_ena;
-        o_empty = o_empty_ena;
+        o_write_ready = o_write_ready_ena;
+        o_read_ready = o_read_ready_ena;
         o_data = o_data_ena;
       end
       DISABLED : begin
-        o_full = o_full_dis;
-        o_empty = o_empty_dis;
+        o_write_ready = o_write_ready_dis;
+        o_read_ready = o_read_ready_dis;
         o_data = o_data_dis;
       end
       default : begin
-        o_full = o_full_dis;
-        o_empty = o_empty_dis;
+        o_write_ready = o_write_ready_dis;
+        o_read_ready = o_read_ready_dis;
         o_data = o_data_dis;
       end
     endcase
@@ -145,13 +145,13 @@ module register_tree_tb;
       random_value = $urandom_range(1, 1023);
       enqueue(random_value);
     end
-    assert (o_full) else begin error_count++; $error("The queue should be filled by the intialization!"); end;
+    assert (!o_write_ready) else begin error_count++; $error("The queue should be filled by the intialization!"); end;
 
     // Test Case 1: Dequeue nodes with ENQ_ENA enabled
     $display("\nTest Case 1: Dequeue Test (ENQ_ENA enabled)");
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
       end else begin
         assert (o_data == '0) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
@@ -165,7 +165,7 @@ module register_tree_tb;
       enqueue(random_value);
       assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
-    assert (o_full) else begin error_count++; $error("The queue should be filled after enqueue!"); end;
+    assert (!o_write_ready) else begin error_count++; $error("The queue should be filled after enqueue!"); end;
 
     // Test Case 3: Replace nodes with ENQ_ENA enabled
     $display("\nTest Case 3: Replace Test (ENQ_ENA enabled)");
@@ -187,7 +187,7 @@ module register_tree_tb;
         end
         DEQUEUE: begin
           dequeue();
-          if (!o_empty) begin
+          if (o_read_ready) begin
             assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
           end else begin
             assert (o_data == '0) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
@@ -225,11 +225,11 @@ module register_tree_tb;
 
     // Test Case 4: Dequeue Test with ENQ_ENA disabled
     $display("\nTest Case 4: Dequeue Test (ENQ_ENA disabled)");
-    assert (o_full)
+    assert (!o_write_ready)
     else begin error_count++; $error("The queue should be filled by the intialization!"); end;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue_enq_0[0])
         else
           begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
@@ -268,7 +268,7 @@ module register_tree_tb;
       end
       assert (!error_flag) else begin error_count++; $error("The queue should not have change!"); end;
     end
-    assert (!o_full && !o_empty) else begin error_count++; $error("The queue should not do anything!"); end;
+    assert (o_write_ready && o_read_ready) else begin error_count++; $error("The queue should not do anything!"); end;
 
     // Test Case 6: Test Replace operation with ENQ_ENA disabled
     $display("\nTest Case 6: Replace Test (ENQ_ENA disabled)");
@@ -287,7 +287,7 @@ module register_tree_tb;
       case (random_operation)
         DEQUEUE: begin
           dequeue();
-          if (!o_empty) begin
+          if (o_read_ready) begin
             assert (o_data == ref_queue_enq_0[0])
             else
               begin error_count++; $error(
@@ -325,7 +325,7 @@ module register_tree_tb;
 
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (!o_full) begin
+      if (o_write_ready) begin
         case (current_mode)
           ENABLED: begin
             i_wrt_ena = 1;
@@ -370,7 +370,7 @@ module register_tree_tb;
 
   task automatic dequeue();
     begin
-      if (!o_empty) begin
+      if (o_read_ready) begin
         case (current_mode)
         ENABLED: begin        
           i_wrt_ena  = 0;
@@ -417,7 +417,7 @@ module register_tree_tb;
         i_wrt_ena  = 1;
         i_read_ena = 1;
         i_data_ena = value;
-        if (o_empty) begin
+        if (!o_read_ready) begin
           ref_queue_enq_1[ref_queue_enq_1_size] = value;
           ref_queue_enq_1_size++;
           
@@ -431,7 +431,7 @@ module register_tree_tb;
         i_wrt_dis  = 1;
         i_read_dis = 1;
         i_data_dis = value;
-        if (o_empty) begin
+        if (!o_read_ready) begin
           ref_queue_enq_0[ref_queue_enq_0_size] = value;
           ref_queue_enq_0_size++;
           rsort_dis();

--- a/hwpq/register_tree/rtl/sim/register_tree_tb.sv
+++ b/hwpq/register_tree/rtl/sim/register_tree_tb.sv
@@ -326,21 +326,26 @@ module register_tree_tb;
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     begin
       if (!o_full) begin
-        if (current_mode == ENABLED) begin
-          i_wrt_ena = 1;
-          i_read_ena = 0;
-          i_data_ena = value;
+        case (current_mode)
+          ENABLED: begin
+            i_wrt_ena = 1;
+            i_read_ena = 0;
+            i_data_ena = value;
 
-          ref_queue_enq_1[ref_queue_enq_1_size] = value;
-          ref_queue_enq_1_size++;
-      
-          rsort_ena();
-        end else if (current_mode == DISABLED) begin
-          i_wrt_dis = 1;
-          i_read_dis = 0;
-          i_data_dis = value;
-//          $display("Enqueue attempt with ENQ_ENA disabled - should have no effect");
-        end
+            ref_queue_enq_1[ref_queue_enq_1_size] = value;
+            ref_queue_enq_1_size++;
+        
+            rsort_ena();
+          end
+          DISABLED: begin
+            i_wrt_dis = 1;
+            i_read_dis = 0;
+            i_data_dis = value;
+          end
+          default: begin
+            $display("Enqueue: Invalid mode, skipping enqueue");
+          end 
+          endcase
       end else begin
         $display("Enqueue: Queue full, skipping enqueue");
       end
@@ -349,15 +354,25 @@ module register_tree_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat ($clog2(QUEUE_SIZE)) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK); // should have no effects
+      case (current_mode)
+        ENABLED: begin
+          repeat ($clog2(QUEUE_SIZE)) @(posedge CLK);
+        end
+        DISABLED: begin
+          repeat (2) @(posedge CLK); // should have no effects
+        end
+        default: begin
+          $display("Enqueue: Invalid mode, skipping enqueue");
+        end
+      endcase
     end
   endtask
 
   task automatic dequeue();
     begin
       if (!o_empty) begin
-        if (current_mode == ENABLED) begin
+        case (current_mode)
+        ENABLED: begin        
           i_wrt_ena  = 0;
           i_read_ena = 1;
           i_data_ena = 0;
@@ -367,8 +382,8 @@ module register_tree_tb;
           end
           ref_queue_enq_1[ref_queue_enq_1_size-1] = '0; 
           ref_queue_enq_1_size--;
-
-        end else if (current_mode == DISABLED) begin
+        end 
+        DISABLED: begin
           i_wrt_dis  = 0;
           i_read_dis = 1;
           i_data_dis = 0;
@@ -378,8 +393,10 @@ module register_tree_tb;
           end
           ref_queue_enq_0[ref_queue_enq_0_size-1] = '0; 
           ref_queue_enq_0_size--;
-
         end
+        default:
+          $display("Invalid option, skipping dequeue");
+        endcase
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
@@ -395,7 +412,8 @@ module register_tree_tb;
 
   task automatic replace(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (current_mode == ENABLED) begin
+      case (current_mode)
+      ENABLED: begin
         i_wrt_ena  = 1;
         i_read_ena = 1;
         i_data_ena = value;
@@ -408,7 +426,8 @@ module register_tree_tb;
           ref_queue_enq_1[0] = value;
           rsort_ena();
         end
-      end else if (current_mode == DISABLED) begin
+      end 
+      DISABLED: begin
         i_wrt_dis  = 1;
         i_read_dis = 1;
         i_data_dis = value;
@@ -421,6 +440,7 @@ module register_tree_tb;
           rsort_dis();
         end
       end
+      endcase
       @(posedge CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
@@ -432,15 +452,18 @@ module register_tree_tb;
 
   task automatic replace_init(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (current_mode == ENABLED) begin
-        i_wrt_ena  = 1;
-        i_read_ena = 1;
-        i_data_ena = value;
-      end else if (current_mode == DISABLED) begin
-        i_wrt_dis  = 1;
-        i_read_dis = 1;
-        i_data_dis = value;
-      end
+      case(current_mode)
+        ENABLED: begin
+          i_wrt_ena  = 1;
+          i_read_ena = 1;
+          i_data_ena = value;
+        end
+        DISABLED: begin
+          i_wrt_dis  = 1;
+          i_read_dis = 1;
+          i_data_dis = value;
+        end
+      endcase
       @(posedge CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;

--- a/hwpq/register_tree/rtl/sim/register_tree_tb.sv
+++ b/hwpq/register_tree/rtl/sim/register_tree_tb.sv
@@ -388,8 +388,8 @@ module register_tree_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+      
+      repeat (2) @(posedge CLK);
     end
   endtask
 
@@ -426,9 +426,8 @@ module register_tree_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
-    end
+      repeat (2) @(posedge CLK); 
+    end  
   endtask
 
   task automatic replace_init(input logic [DATA_WIDTH-1:0] value);
@@ -447,8 +446,7 @@ module register_tree_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+      repeat (2) @(posedge CLK);
     end
   endtask
 

--- a/hwpq/register_tree/rtl/src/register_tree.sv
+++ b/hwpq/register_tree/rtl/src/register_tree.sv
@@ -17,8 +17,8 @@
           i_wrt - Write/insert command (enqueue/replace operation)
           i_read - Read/pop command (dequeue/replace operation)
           i_data - Input data to be enqueued (or used for replace)
-  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
-           o_empty - High when the queue is empty
+  Outputs: o_write_ready - High when the queue has room to accept a write
+           o_read_ready - High when the queue holds data available to read
            o_data - Output data from the highest priority element
 *******************************************************************************/
 
@@ -35,8 +35,8 @@ module register_tree #(
     input var logic i_read,
     input var logic [DATA_WIDTH-1:0] i_data,
     // Outputs
-    output var logic o_full,
-    output var logic o_empty,
+    output var logic o_write_ready,
+    output var logic o_read_ready,
     output var logic [DATA_WIDTH-1:0] o_data
 );
 
@@ -101,8 +101,8 @@ module register_tree #(
   // Size counter signals
   assign empty = (size <= 0);
   assign full = (size >= QUEUE_SIZE);
-  assign o_full = full;
-  assign o_empty = empty;
+  assign o_write_ready = !full;
+  assign o_read_ready = !empty;
   assign o_data = queue[0];
 
   //----------------------------------------------------------------------

--- a/hwpq/register_tree/rtl/src/register_tree.sv
+++ b/hwpq/register_tree/rtl/src/register_tree.sv
@@ -1,5 +1,27 @@
 `default_nettype none
 
+/*******************************************************************************
+  Module Name: register_tree
+  Date: 2026/06/22
+  Description: A register-based priority queue that preserves the heap
+               property across a binary tree of registers, closely
+               resembling a software heap. Enqueue searches for the leftmost
+               invalid entry and reorders the tree; dequeue and replace
+               remove/update the root in a single cycle while alternating-
+               level compare-and-swap operations restore heap order.
+  Parameters: ENQ_ENA - Enables the enqueue datapath when set
+              QUEUE_SIZE - Maximum number of elements in the priority queue
+              DATA_WIDTH - Bit width of data elements
+  Inputs: i_CLK - System clock
+          i_RSTn - Active-low reset signal
+          i_wrt - Write/insert command (enqueue/replace operation)
+          i_read - Read/pop command (dequeue/replace operation)
+          i_data - Input data to be enqueued (or used for replace)
+  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
+           o_empty - High when the queue is empty
+           o_data - Output data from the highest priority element
+*******************************************************************************/
+
 module register_tree #(
     parameter bit ENQ_ENA = 1,    // Define if user would like to enable enqueue
     parameter int QUEUE_SIZE = 4095,

--- a/hwpq/register_tree_pipelined/rtl/sim/register_tree_pipelined_tb.sv
+++ b/hwpq/register_tree_pipelined/rtl/sim/register_tree_pipelined_tb.sv
@@ -117,6 +117,8 @@ module register_tree_pipelined_tb;
   // Clock generation: 10ns period
   always #5 CLK <= ~CLK;
 
+  int error_count = 0;
+
   initial begin
     // Initialize signals
     CLK = 0;
@@ -147,7 +149,7 @@ module register_tree_pipelined_tb;
       enqueue(random_value);
     end
     assert (o_full)
-    else $error("The queue should be filled by the intialization!");
+    else begin error_count++; $error("The queue should be filled by the intialization!"); end;
 
     // Test Case 1: Dequeue nodes with ENQ_ENA enabled
     $display("\nTest Case 1: Dequeue Test (ENQ_ENA enabled)");
@@ -156,10 +158,10 @@ module register_tree_pipelined_tb;
       if (!o_empty) begin
         assert (o_data == ref_queue_enq_1[0])
         else
-          $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+          begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
       end else begin
         assert (o_data == '0)
-        else $error("Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+        else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -170,10 +172,10 @@ module register_tree_pipelined_tb;
       enqueue(random_value);
       assert (o_data == ref_queue_enq_1[0])
       else
-        $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+        begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
     assert (o_full)
-    else $error("The queue should be filled after enqueue!");
+    else begin error_count++; $error("The queue should be filled after enqueue!"); end;
 
     // Test Case 3: Replace nodes with ENQ_ENA enabled
     $display("\nTest Case 3: Replace Test (ENQ_ENA enabled)");
@@ -182,7 +184,7 @@ module register_tree_pipelined_tb;
       replace(random_value);
       assert (o_data == ref_queue_enq_1[0])
       else
-        $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+        begin error_count++; $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
 
     // Test case 4: Random opertaion for 50 times
@@ -195,25 +197,25 @@ module register_tree_pipelined_tb;
           enqueue(random_value);
           assert (o_data == ref_queue_enq_1[0])
           else
-            $error(
+            begin error_count++; $error(
                 "Random Enqueue: Node value mismatch -> expected %d, got %d",
                 ref_queue_enq_1[0],
                 o_data
-            );
+            ); end;
         end
         DEQUEUE: begin
           dequeue();
           if (!o_empty) begin
             assert (o_data == ref_queue_enq_1[0])
             else
-              $error(
+              begin error_count++; $error(
                   "Random Dequeue: Node value mismatch -> expected %d, got %d",
                   ref_queue_enq_1[0],
                   o_data
-              );
+              ); end;
           end else begin
             assert (o_data == '0)
-            else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+            else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
         REPLACE: begin
@@ -221,11 +223,11 @@ module register_tree_pipelined_tb;
           replace(random_value);
           assert (o_data == ref_queue_enq_1[0])
           else
-            $error(
+            begin error_count++; $error(
                 "Random Replace: Node value mismatch -> expected %d, got %d",
                 ref_queue_enq_1[0],
                 o_data
-            );
+            ); end;
         end
       endcase
     end
@@ -255,16 +257,16 @@ module register_tree_pipelined_tb;
     // Test Case 4: Dequeue Test with ENQ_ENA disabled
     $display("\nTest Case 4: Dequeue Test (ENQ_ENA disabled)");
     assert (o_full)
-    else $error("The queue should be filled by the intialization!");
+    else begin error_count++; $error("The queue should be filled by the intialization!"); end;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue_enq_0[0])
         else
-          $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+          begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
       end else begin
         assert (o_data == 'd0)
-        else $error("Dequeue: Node value mismatch -> expected %d, got %d", 'd0, o_data);
+        else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", 'd0, o_data); end;
       end
     end
 
@@ -277,9 +279,9 @@ module register_tree_pipelined_tb;
       enqueue(random_value);
       assert (o_data == ref_queue_enq_0[0])
       else
-        $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+        begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
     end
-    assert (o_data == o_data_prev) else $error("The queue should not have change!");
+    assert (o_data == o_data_prev) else begin error_count++; $error("The queue should not have change!"); end;
     begin
       bit queues_match;
       bit error_flag;
@@ -295,9 +297,9 @@ module register_tree_pipelined_tb;
           end
         end
       end
-      assert (!error_flag) else $error("The queue should not have change!");
+      assert (!error_flag) else begin error_count++; $error("The queue should not have change!"); end;
     end
-    assert (!o_full && !o_empty) else $error("The queue should not do anything!");
+    assert (!o_full && !o_empty) else begin error_count++; $error("The queue should not do anything!"); end;
 
     // Test Case 6: Test Replace operation with ENQ_ENA disabled
     $display("\nTest Case 6: Replace Test (ENQ_ENA disabled)");
@@ -306,7 +308,7 @@ module register_tree_pipelined_tb;
       replace(random_value);
       assert (o_data == ref_queue_enq_0[0])
       else
-        $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+        begin error_count++; $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
     end
 
     // Test case 8: Random opertaion for 50 times
@@ -319,14 +321,14 @@ module register_tree_pipelined_tb;
           if (!o_empty) begin
             assert (o_data == ref_queue_enq_0[0])
             else
-              $error(
+              begin error_count++; $error(
                   "Random Dequeue: Node value mismatch -> expected %d, got %d",
                   ref_queue_enq_0[0],
                   o_data
-              );
+              ); end;
           end else begin
             assert (o_data == '0)
-            else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+            else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
         REPLACE: begin
@@ -334,17 +336,22 @@ module register_tree_pipelined_tb;
           replace(random_value);
           assert (o_data == ref_queue_enq_0[0])
           else
-            $error(
+            begin error_count++; $error(
                 "Random Replace: Node value mismatch -> expected %d, got %d",
                 ref_queue_enq_0[0],
                 o_data
-            );
+            ); end;
         end
       endcase
     end
 
-    $display("\nTest completed!");
-    $finish;
+    if (error_count == 0) begin
+      $display("\nTest completed!");
+      $finish;
+    end else begin
+      $display("\n%0d error(s) detected during simulation.", error_count);
+      $fatal(1, "Test FAILED with %0d error(s).", error_count);
+    end
   end
 
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);

--- a/hwpq/register_tree_pipelined/rtl/sim/register_tree_pipelined_tb.sv
+++ b/hwpq/register_tree_pipelined/rtl/sim/register_tree_pipelined_tb.sv
@@ -6,8 +6,8 @@ module register_tree_pipelined_tb;
   localparam int DATA_WIDTH = 16;
 
   // Clock and reset signals
-  logic                  CLK;
-  logic                  RSTn;
+  logic                  i_CLK;
+  logic                  i_RSTn;
 
   // Input signals - for ENQ_ENA enabled
   logic                  i_wrt_ena;
@@ -68,8 +68,8 @@ module register_tree_pipelined_tb;
       .QUEUE_SIZE(QUEUE_SIZE),
       .DATA_WIDTH(DATA_WIDTH)
   ) u_RegisterTree_ena (
-      .i_CLK  (CLK),
-      .i_RSTn (RSTn),
+      .i_CLK  (i_CLK),
+      .i_RSTn (i_RSTn),
       .i_wrt  (i_wrt_ena),
       .i_read (i_read_ena),
       .i_data (i_data_ena),
@@ -84,8 +84,8 @@ module register_tree_pipelined_tb;
       .QUEUE_SIZE(QUEUE_SIZE),
       .DATA_WIDTH(DATA_WIDTH)
   ) u_RegisterTree_dis (
-      .i_CLK  (CLK),
-      .i_RSTn (RSTn),
+      .i_CLK  (i_CLK),
+      .i_RSTn (i_RSTn),
       .i_wrt  (i_wrt_dis),
       .i_read (i_read_dis),
       .i_data (i_data_dis),
@@ -115,13 +115,13 @@ module register_tree_pipelined_tb;
   end
 
   // Clock generation: 10ns period
-  always #5 CLK <= ~CLK;
+  always #5 i_CLK <= ~i_CLK;
 
   int error_count = 0;
 
   initial begin
     // Initialize signals
-    CLK = 0;
+    i_CLK = 0;
     i_wrt_ena = 0;
     i_read_ena = 0;
     i_data_ena = 0;
@@ -134,10 +134,10 @@ module register_tree_pipelined_tb;
     ref_queue_prev = {};
 
     // Reset the modules
-    RSTn = 0;
-    @(posedge CLK);
-    RSTn = 1;
-    @(posedge CLK);
+    i_RSTn = 0;
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    @(posedge i_CLK);
 
     // Test with ENQ_ENA enabled
     $display("\n=== Testing with ENQ_ENA enabled ===");
@@ -237,10 +237,10 @@ module register_tree_pipelined_tb;
     current_mode = DISABLED;
 
     // Reset the modules
-    RSTn = 0;
-    @(posedge CLK);
-    RSTn = 1;
-    @(posedge CLK);
+    i_RSTn = 0;
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    @(posedge i_CLK);
 
     // Initialize queue inside enqueue disabled module
     $display("\nInitializing enqueue disabled module by replacing into it");
@@ -252,7 +252,7 @@ module register_tree_pipelined_tb;
     end
     rsort_dis();
 
-    repeat (4) @(posedge CLK);
+    repeat (4) @(posedge i_CLK);
 
     // Test Case 4: Dequeue Test with ENQ_ENA disabled
     $display("\nTest Case 4: Dequeue Test (ENQ_ENA disabled)");
@@ -381,17 +381,17 @@ module register_tree_pipelined_tb;
       end else begin
         $display("Enqueue: Queue full, skipping enqueue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
       case (current_mode)
         ENABLED: begin
-          repeat ($clog2(QUEUE_SIZE)) @(posedge CLK);
+          repeat ($clog2(QUEUE_SIZE)) @(posedge i_CLK);
         end
         DISABLED: begin
-          repeat (2) @(posedge CLK); // should have no effects
+          repeat (2) @(posedge i_CLK); // should have no effects
         end
         default: begin
           $display("Enqueue: Invalid mode, skipping enqueue");
@@ -433,13 +433,13 @@ module register_tree_pipelined_tb;
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
 
-      repeat (2) @(posedge CLK);
+      repeat (2) @(posedge i_CLK);
     end
   endtask
 
@@ -477,13 +477,13 @@ module register_tree_pipelined_tb;
           $display("Replace: Invalid mode, skipping replace");
         end
       endcase
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
 
-      repeat (2) @(posedge CLK);
+      repeat (2) @(posedge i_CLK);
     end
   endtask
 
@@ -504,13 +504,13 @@ module register_tree_pipelined_tb;
           $display("Replace: Invalid mode, skipping replace");
         end
       endcase
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
 
-      repeat (2) @(posedge CLK);
+      repeat (2) @(posedge i_CLK);
     end
   endtask
 

--- a/hwpq/register_tree_pipelined/rtl/sim/register_tree_pipelined_tb.sv
+++ b/hwpq/register_tree_pipelined/rtl/sim/register_tree_pipelined_tb.sv
@@ -419,8 +419,8 @@ module register_tree_pipelined_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+
+      repeat (2) @(posedge CLK);
     end
   endtask
 
@@ -457,8 +457,8 @@ module register_tree_pipelined_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+
+      repeat (2) @(posedge CLK);
     end
   endtask
 
@@ -478,8 +478,8 @@ module register_tree_pipelined_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+
+      repeat (2) @(posedge CLK);
     end
   endtask
 

--- a/hwpq/register_tree_pipelined/rtl/sim/register_tree_pipelined_tb.sv
+++ b/hwpq/register_tree_pipelined/rtl/sim/register_tree_pipelined_tb.sv
@@ -20,18 +20,18 @@ module register_tree_pipelined_tb;
   logic [DATA_WIDTH-1:0] i_data_dis;
 
   // Output signals - for ENQ_ENA enabled
-  logic                  o_full_ena;
-  logic                  o_empty_ena;
+  logic                  o_write_ready_ena;
+  logic                  o_read_ready_ena;
   logic [DATA_WIDTH-1:0] o_data_ena;
 
   // Output signals - for ENQ_ENA disabled
-  logic                  o_full_dis;
-  logic                  o_empty_dis;
+  logic                  o_write_ready_dis;
+  logic                  o_read_ready_dis;
   logic [DATA_WIDTH-1:0] o_data_dis;
 
   // Current active outputs for testing
-  logic                  o_full;
-  logic                  o_empty;
+  logic                  o_write_ready;
+  logic                  o_read_ready;
   logic [DATA_WIDTH-1:0] o_data;
   logic [DATA_WIDTH-1:0] o_data_prev;
 
@@ -73,8 +73,8 @@ module register_tree_pipelined_tb;
       .i_wrt  (i_wrt_ena),
       .i_read (i_read_ena),
       .i_data (i_data_ena),
-      .o_full (o_full_ena),
-      .o_empty(o_empty_ena),
+      .o_write_ready (o_write_ready_ena),
+      .o_read_ready(o_read_ready_ena),
       .o_data (o_data_ena)
   );
 
@@ -89,26 +89,26 @@ module register_tree_pipelined_tb;
       .i_wrt  (i_wrt_dis),
       .i_read (i_read_dis),
       .i_data (i_data_dis),
-      .o_full (o_full_dis),
-      .o_empty(o_empty_dis),
+      .o_write_ready (o_write_ready_dis),
+      .o_read_ready(o_read_ready_dis),
       .o_data (o_data_dis)
   );
 
   always_comb begin : output_signal_switch
     case (current_mode)
       ENABLED: begin
-        o_full  = o_full_ena;
-        o_empty = o_empty_ena;
+        o_write_ready  = o_write_ready_ena;
+        o_read_ready = o_read_ready_ena;
         o_data  = o_data_ena;
       end
       DISABLED: begin
-        o_full  = o_full_dis;
-        o_empty = o_empty_dis;
+        o_write_ready  = o_write_ready_dis;
+        o_read_ready = o_read_ready_dis;
         o_data  = o_data_dis;
       end
       default: begin
-        o_full  = o_full_dis;
-        o_empty = o_empty_dis;
+        o_write_ready  = o_write_ready_dis;
+        o_read_ready = o_read_ready_dis;
         o_data  = o_data_dis;
       end
     endcase
@@ -148,14 +148,14 @@ module register_tree_pipelined_tb;
       random_value = $urandom_range(1, 1023);
       enqueue(random_value);
     end
-    assert (o_full)
+    assert (!o_write_ready)
     else begin error_count++; $error("The queue should be filled by the intialization!"); end;
 
     // Test Case 1: Dequeue nodes with ENQ_ENA enabled
     $display("\nTest Case 1: Dequeue Test (ENQ_ENA enabled)");
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue_enq_1[0])
         else
           begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
@@ -174,7 +174,7 @@ module register_tree_pipelined_tb;
       else
         begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
-    assert (o_full)
+    assert (!o_write_ready)
     else begin error_count++; $error("The queue should be filled after enqueue!"); end;
 
     // Test Case 3: Replace nodes with ENQ_ENA enabled
@@ -205,7 +205,7 @@ module register_tree_pipelined_tb;
         end
         DEQUEUE: begin
           dequeue();
-          if (!o_empty) begin
+          if (o_read_ready) begin
             assert (o_data == ref_queue_enq_1[0])
             else
               begin error_count++; $error(
@@ -256,11 +256,11 @@ module register_tree_pipelined_tb;
 
     // Test Case 4: Dequeue Test with ENQ_ENA disabled
     $display("\nTest Case 4: Dequeue Test (ENQ_ENA disabled)");
-    assert (o_full)
+    assert (!o_write_ready)
     else begin error_count++; $error("The queue should be filled by the intialization!"); end;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue_enq_0[0])
         else
           begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
@@ -299,7 +299,7 @@ module register_tree_pipelined_tb;
       end
       assert (!error_flag) else begin error_count++; $error("The queue should not have change!"); end;
     end
-    assert (!o_full && !o_empty) else begin error_count++; $error("The queue should not do anything!"); end;
+    assert (o_write_ready && o_read_ready) else begin error_count++; $error("The queue should not do anything!"); end;
 
     // Test Case 6: Test Replace operation with ENQ_ENA disabled
     $display("\nTest Case 6: Replace Test (ENQ_ENA disabled)");
@@ -318,7 +318,7 @@ module register_tree_pipelined_tb;
       case (random_operation)
         DEQUEUE: begin
           dequeue();
-          if (!o_empty) begin
+          if (o_read_ready) begin
             assert (o_data == ref_queue_enq_0[0])
             else
               begin error_count++; $error(
@@ -356,7 +356,7 @@ module register_tree_pipelined_tb;
 
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (!o_full) begin
+      if (o_write_ready) begin
         case (current_mode)
           ENABLED: begin
             i_wrt_ena = 1;
@@ -402,7 +402,7 @@ module register_tree_pipelined_tb;
 
   task automatic dequeue();
     begin
-      if (!o_empty) begin
+      if (o_read_ready) begin
         case (current_mode)
           ENABLED: begin
             i_wrt_ena  = 0;
@@ -450,7 +450,7 @@ module register_tree_pipelined_tb;
           i_wrt_ena  = 1;
           i_read_ena = 1;
           i_data_ena = value;
-          if (o_empty) begin
+          if (!o_read_ready) begin
             ref_queue_enq_1[ref_queue_enq_1_size] = value;
             ref_queue_enq_1_size++;
 
@@ -464,7 +464,7 @@ module register_tree_pipelined_tb;
           i_wrt_dis  = 1;
           i_read_dis = 1;
           i_data_dis = value;
-          if (o_empty) begin
+          if (!o_read_ready) begin
             ref_queue_enq_0[ref_queue_enq_0_size] = value;
             ref_queue_enq_0_size++;
             rsort_dis();

--- a/hwpq/register_tree_pipelined/rtl/sim/register_tree_pipelined_tb.sv
+++ b/hwpq/register_tree_pipelined/rtl/sim/register_tree_pipelined_tb.sv
@@ -357,21 +357,27 @@ module register_tree_pipelined_tb;
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     begin
       if (!o_full) begin
-        if (current_mode == ENABLED) begin
-          i_wrt_ena = 1;
-          i_read_ena = 0;
-          i_data_ena = value;
+        case (current_mode)
+          ENABLED: begin
+            i_wrt_ena = 1;
+            i_read_ena = 0;
+            i_data_ena = value;
 
-          ref_queue_enq_1[ref_queue_enq_1_size] = value;
-          ref_queue_enq_1_size++;
-      
-          rsort_ena();
-        end else if (current_mode == DISABLED) begin
-          i_wrt_dis = 1;
-          i_read_dis = 0;
-          i_data_dis = value;
-//          $display("Enqueue attempt with ENQ_ENA disabled - should have no effect");
-        end
+            ref_queue_enq_1[ref_queue_enq_1_size] = value;
+            ref_queue_enq_1_size++;
+
+            rsort_ena();
+          end
+          DISABLED: begin
+            i_wrt_dis = 1;
+            i_read_dis = 0;
+            i_data_dis = value;
+//            $display("Enqueue attempt with ENQ_ENA disabled - should have no effect");
+          end
+          default: begin
+            $display("Enqueue: Invalid mode, skipping enqueue");
+          end
+        endcase
       end else begin
         $display("Enqueue: Queue full, skipping enqueue");
       end
@@ -380,37 +386,50 @@ module register_tree_pipelined_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat ($clog2(QUEUE_SIZE)) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK); // should have no effects
+      case (current_mode)
+        ENABLED: begin
+          repeat ($clog2(QUEUE_SIZE)) @(posedge CLK);
+        end
+        DISABLED: begin
+          repeat (2) @(posedge CLK); // should have no effects
+        end
+        default: begin
+          $display("Enqueue: Invalid mode, skipping enqueue");
+        end
+      endcase
     end
   endtask
 
   task automatic dequeue();
     begin
       if (!o_empty) begin
-        if (current_mode == ENABLED) begin
-          i_wrt_ena  = 0;
-          i_read_ena = 1;
-          i_data_ena = 0;
+        case (current_mode)
+          ENABLED: begin
+            i_wrt_ena  = 0;
+            i_read_ena = 1;
+            i_data_ena = 0;
 
-          for (int i = 0; i < ref_queue_enq_1_size - 1; i++) begin
-            ref_queue_enq_1[i] = ref_queue_enq_1[i+1];
+            for (int i = 0; i < ref_queue_enq_1_size - 1; i++) begin
+              ref_queue_enq_1[i] = ref_queue_enq_1[i+1];
+            end
+            ref_queue_enq_1[ref_queue_enq_1_size-1] = '0;
+            ref_queue_enq_1_size--;
           end
-          ref_queue_enq_1[ref_queue_enq_1_size-1] = '0; 
-          ref_queue_enq_1_size--;
+          DISABLED: begin
+            i_wrt_dis  = 0;
+            i_read_dis = 1;
+            i_data_dis = 0;
 
-        end else if (current_mode == DISABLED) begin
-          i_wrt_dis  = 0;
-          i_read_dis = 1;
-          i_data_dis = 0;
-
-          for (int i = 0; i < ref_queue_enq_0_size - 1; i++) begin
-            ref_queue_enq_0[i] = ref_queue_enq_0[i+1];
+            for (int i = 0; i < ref_queue_enq_0_size - 1; i++) begin
+              ref_queue_enq_0[i] = ref_queue_enq_0[i+1];
+            end
+            ref_queue_enq_0[ref_queue_enq_0_size-1] = '0;
+            ref_queue_enq_0_size--;
           end
-          ref_queue_enq_0[ref_queue_enq_0_size-1] = '0; 
-          ref_queue_enq_0_size--;
-
-        end
+          default: begin
+            $display("Dequeue: Invalid mode, skipping dequeue");
+          end
+        endcase
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
@@ -426,32 +445,38 @@ module register_tree_pipelined_tb;
 
   task automatic replace(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (current_mode == ENABLED) begin
-        i_wrt_ena  = 1;
-        i_read_ena = 1;
-        i_data_ena = value;
-        if (o_empty) begin
-          ref_queue_enq_1[ref_queue_enq_1_size] = value;
-          ref_queue_enq_1_size++;
-          
-          rsort_ena();
-        end else begin
-          ref_queue_enq_1[0] = value;
-          rsort_ena();
+      case (current_mode)
+        ENABLED: begin
+          i_wrt_ena  = 1;
+          i_read_ena = 1;
+          i_data_ena = value;
+          if (o_empty) begin
+            ref_queue_enq_1[ref_queue_enq_1_size] = value;
+            ref_queue_enq_1_size++;
+
+            rsort_ena();
+          end else begin
+            ref_queue_enq_1[0] = value;
+            rsort_ena();
+          end
         end
-      end else if (current_mode == DISABLED) begin
-        i_wrt_dis  = 1;
-        i_read_dis = 1;
-        i_data_dis = value;
-        if (o_empty) begin
-          ref_queue_enq_0[ref_queue_enq_0_size] = value;
-          ref_queue_enq_0_size++;
-          rsort_dis();
-        end else begin
-          ref_queue_enq_0[0] = value;
-          rsort_dis();
+        DISABLED: begin
+          i_wrt_dis  = 1;
+          i_read_dis = 1;
+          i_data_dis = value;
+          if (o_empty) begin
+            ref_queue_enq_0[ref_queue_enq_0_size] = value;
+            ref_queue_enq_0_size++;
+            rsort_dis();
+          end else begin
+            ref_queue_enq_0[0] = value;
+            rsort_dis();
+          end
         end
-      end
+        default: begin
+          $display("Replace: Invalid mode, skipping replace");
+        end
+      endcase
       @(posedge CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
@@ -464,15 +489,21 @@ module register_tree_pipelined_tb;
 
   task automatic replace_init(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (current_mode == ENABLED) begin
-        i_wrt_ena  = 1;
-        i_read_ena = 1;
-        i_data_ena = value;
-      end else if (current_mode == DISABLED) begin
-        i_wrt_dis  = 1;
-        i_read_dis = 1;
-        i_data_dis = value;
-      end
+      case (current_mode)
+        ENABLED: begin
+          i_wrt_ena  = 1;
+          i_read_ena = 1;
+          i_data_ena = value;
+        end
+        DISABLED: begin
+          i_wrt_dis  = 1;
+          i_read_dis = 1;
+          i_data_dis = value;
+        end
+        default: begin
+          $display("Replace: Invalid mode, skipping replace");
+        end
+      endcase
       @(posedge CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;

--- a/hwpq/register_tree_pipelined/rtl/src/register_tree_pipelined.sv
+++ b/hwpq/register_tree_pipelined/rtl/src/register_tree_pipelined.sv
@@ -1,5 +1,25 @@
 `default_nettype none
 
+/*******************************************************************************
+  Module Name: register_tree_pipelined
+  Date: 2026/06/21
+  Description: A pipelined version of the register tree architecture that
+               divides the compare-and-swap logic between clock cycles to
+               reduce combinational path length, at the cost of enqueue
+               taking two cycles to propagate a new entry into place.
+  Parameters: ENQ_ENA - Enables the enqueue datapath when set
+              QUEUE_SIZE - Maximum number of elements in the priority queue
+              DATA_WIDTH - Bit width of data elements
+  Inputs: i_CLK - System clock
+          i_RSTn - Active-low reset signal
+          i_wrt - Write/insert command (enqueue/replace operation)
+          i_read - Read/pop command (dequeue/replace operation)
+          i_data - Input data to be enqueued (or used for replace)
+  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
+           o_empty - High when the queue is empty
+           o_data - Output data from the highest priority element
+*******************************************************************************/
+
 module register_tree_pipelined #(
     parameter bit ENQ_ENA = 1,
     parameter int QUEUE_SIZE = 15,

--- a/hwpq/register_tree_pipelined/rtl/src/register_tree_pipelined.sv
+++ b/hwpq/register_tree_pipelined/rtl/src/register_tree_pipelined.sv
@@ -15,8 +15,8 @@
           i_wrt - Write/insert command (enqueue/replace operation)
           i_read - Read/pop command (dequeue/replace operation)
           i_data - Input data to be enqueued (or used for replace)
-  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
-           o_empty - High when the queue is empty
+  Outputs: o_write_ready - High when the queue has room to accept a write
+           o_read_ready - High when the queue holds data available to read
            o_data - Output data from the highest priority element
 *******************************************************************************/
 
@@ -33,8 +33,8 @@ module register_tree_pipelined #(
     input var logic i_read,
     input var logic [DATA_WIDTH-1:0] i_data,
     // Outputs
-    output var logic o_full,
-    output var logic o_empty,
+    output var logic o_write_ready,
+    output var logic o_read_ready,
     output var logic [DATA_WIDTH-1:0] o_data
 );
 
@@ -84,8 +84,8 @@ module register_tree_pipelined #(
 
   assign empty = (size <= 0) ? 1'b1 : 1'b0;
   assign full = (size >= QUEUE_SIZE) ? 1'b1 : 1'b0;
-  assign o_full = full;
-  assign o_empty = empty;
+  assign o_write_ready = !full;
+  assign o_read_ready = !empty;
   assign o_data = queue[0];
 
   //----------------------------------------------------------------------

--- a/hwpq/systolic_array/rtl/sim/systolic_array_bug_tb.sv
+++ b/hwpq/systolic_array/rtl/sim/systolic_array_bug_tb.sv
@@ -50,6 +50,8 @@ module systolic_array_tb;
   // Clock generation: 10ns period
   always #5 CLK <= ~CLK;
 
+  int error_count = 0;
+
   initial begin
     // Initialize signals
     CLK = 0;
@@ -103,10 +105,10 @@ module systolic_array_tb;
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue[0])
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
         assert (o_data == '0)
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -152,10 +154,10 @@ module systolic_array_tb;
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue[0])
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
         assert (o_data == '0)
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -200,10 +202,10 @@ module systolic_array_tb;
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue[0])
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
         assert (o_data == '0)
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -249,15 +251,20 @@ module systolic_array_tb;
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue[0])
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
         assert (o_data == '0)
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
-    $display("\nTest completed! ");
-    $finish;
+    if (error_count == 0) begin
+      $display("\nTest completed!");
+      $finish;
+    end else begin
+      $display("\n%0d error(s) detected during simulation.", error_count);
+      $fatal(1, "Test FAILED with %0d error(s).", error_count);
+    end
   end
 
   // Task to read root node

--- a/hwpq/systolic_array/rtl/sim/systolic_array_bug_tb.sv
+++ b/hwpq/systolic_array/rtl/sim/systolic_array_bug_tb.sv
@@ -4,8 +4,8 @@ module systolic_array_tb;
   parameter int DATA_WIDTH = 16;
 
   // Clock and reset signals
-  logic                  CLK;
-  logic                  RSTn;
+  logic                  i_CLK;
+  logic                  i_RSTn;
 
   // Input signals
   logic                  i_wrt;
@@ -37,8 +37,8 @@ module systolic_array_tb;
       .QUEUE_SIZE(QUEUE_SIZE),
       .DATA_WIDTH(DATA_WIDTH)
   ) u_SystolicArray (
-      .i_CLK(CLK),
-      .i_RSTn(RSTn),
+      .i_CLK(i_CLK),
+      .i_RSTn(i_RSTn),
       .i_wrt(i_wrt),
       .i_read(i_read),
       .i_data(i_data),
@@ -48,22 +48,22 @@ module systolic_array_tb;
   );
 
   // Clock generation: 10ns period
-  always #5 CLK <= ~CLK;
+  always #5 i_CLK <= ~i_CLK;
 
   int error_count = 0;
 
   initial begin
     // Initialize signals
-    CLK = 0;
-    RSTn = 0;
+    i_CLK = 0;
+    i_RSTn = 0;
     i_wrt = 0;
     i_read = 0;
     i_data = 0;
 
     // Reset the module
-    @(posedge CLK);
-    RSTn = 1;
-    @(posedge CLK);
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    @(posedge i_CLK);
 
     // Test Case 1: Successive decreasing numbers in IB
     $display("\nTest Case 1: Successive decreasing numbers in IB");
@@ -87,7 +87,7 @@ module systolic_array_tb;
     u_SystolicArray.size = 4'd8;
     u_SystolicArray.size_next = 4'd8;
 
-    @(posedge CLK);
+    @(posedge i_CLK);
 
     ref_queue.push_back(16'd1);
     ref_queue.push_back(16'd6);
@@ -107,7 +107,7 @@ module systolic_array_tb;
         end
       end
     end
-    repeat (10) @(posedge CLK);
+    repeat (10) @(posedge i_CLK);
 
     for (int i = 0; i < 8; i++) begin
       dequeue();
@@ -135,7 +135,7 @@ module systolic_array_tb;
     u_SystolicArray.size = 4'd8;
     u_SystolicArray.size_next = 4'd8;
 
-    @(posedge CLK);
+    @(posedge i_CLK);
 
     ref_queue.push_back(16'd1);
     ref_queue.push_back(16'd6);
@@ -156,7 +156,7 @@ module systolic_array_tb;
         end
       end
     end
-    repeat (10) @(posedge CLK);
+    repeat (10) @(posedge i_CLK);
 
     for (int i = 0; i < 8; i++) begin
       dequeue();
@@ -183,7 +183,7 @@ module systolic_array_tb;
     u_SystolicArray.size = 4'd8;
     u_SystolicArray.size_next = 4'd8;
 
-    @(posedge CLK);
+    @(posedge i_CLK);
 
     ref_queue.push_back(16'd1);
     ref_queue.push_back(16'd2);
@@ -204,7 +204,7 @@ module systolic_array_tb;
         end
       end
     end
-    repeat (10) @(posedge CLK);
+    repeat (10) @(posedge i_CLK);
 
     for (int i = 0; i < 8; i++) begin
       dequeue();
@@ -232,7 +232,7 @@ module systolic_array_tb;
     u_SystolicArray.size = 4'd8;
     u_SystolicArray.size_next = 4'd8;
 
-    @(posedge CLK);
+    @(posedge i_CLK);
 
     ref_queue.push_back(16'd1);
     ref_queue.push_back(16'd2);
@@ -253,7 +253,7 @@ module systolic_array_tb;
         end
       end
     end
-    repeat (10) @(posedge CLK);
+    repeat (10) @(posedge i_CLK);
 
     for (int i = 0; i < 8; i++) begin
       dequeue();
@@ -290,10 +290,10 @@ module systolic_array_tb;
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (3) @(posedge CLK);
+      repeat (3) @(posedge i_CLK);
     end
   endtask
 
@@ -319,10 +319,10 @@ module systolic_array_tb;
         $display("Replace: Queue empty, skipping replace");
       end
       
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (2) @(posedge CLK); 
+      repeat (2) @(posedge i_CLK); 
     end
   endtask
 

--- a/hwpq/systolic_array/rtl/sim/systolic_array_bug_tb.sv
+++ b/hwpq/systolic_array/rtl/sim/systolic_array_bug_tb.sv
@@ -68,6 +68,14 @@ module systolic_array_tb;
     // Test Case 1: Successive decreasing numbers in IB
     $display("\nTest Case 1: Successive decreasing numbers in IB");
     ref_queue.delete();
+
+    /* Icarus Verilog (12.0) cannot force an unpacked array, so the DUT buffers are seeded
+      one element at a time with plain hierarchical assignments instead of
+        `force u_SystolicArray.IB = '{16'd1, 16'd6, 16'd4, 16'd2};`
+      which fails with "Assignment to an entire array or to an array slice is not yet supported".
+      Forcing a single word fails too with "cannot force to the word of a variable array". 
+      The same applies to the other test cases below. */
+    
     u_SystolicArray.IB[0] = 16'd1;
     u_SystolicArray.IB[1] = 16'd6;
     u_SystolicArray.IB[2] = 16'd4;

--- a/hwpq/systolic_array/rtl/sim/systolic_array_bug_tb.sv
+++ b/hwpq/systolic_array/rtl/sim/systolic_array_bug_tb.sv
@@ -13,8 +13,8 @@ module systolic_array_tb;
   logic [DATA_WIDTH-1:0] i_data;
 
   // Output signals
-  logic                  o_full;
-  logic                  o_empty;
+  logic                  o_write_ready;
+  logic                  o_read_ready;
   logic [DATA_WIDTH-1:0] o_data;
 
   // Reference array for verification
@@ -42,8 +42,8 @@ module systolic_array_tb;
       .i_wrt(i_wrt),
       .i_read(i_read),
       .i_data(i_data),
-      .o_full(o_full),
-      .o_empty(o_empty),
+      .o_write_ready(o_write_ready),
+      .o_read_ready(o_read_ready),
       .o_data(o_data)
   );
 
@@ -111,7 +111,7 @@ module systolic_array_tb;
 
     for (int i = 0; i < 8; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue[0])
         else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
@@ -160,7 +160,7 @@ module systolic_array_tb;
 
     for (int i = 0; i < 8; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue[0])
         else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
@@ -208,7 +208,7 @@ module systolic_array_tb;
 
     for (int i = 0; i < 8; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue[0])
         else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
@@ -257,7 +257,7 @@ module systolic_array_tb;
 
     for (int i = 0; i < 8; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue[0])
         else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
@@ -278,7 +278,7 @@ module systolic_array_tb;
   // Task to read root node
   task automatic dequeue();
     begin
-      if (!o_empty) begin
+      if (o_read_ready) begin
         i_wrt  = 0;
         i_read = 1;
         for (int i = 0; i < ref_size - 1; i++) begin

--- a/hwpq/systolic_array/rtl/sim/systolic_array_tb.sv
+++ b/hwpq/systolic_array/rtl/sim/systolic_array_tb.sv
@@ -51,6 +51,8 @@ module systolic_array_tb;
   // Clock generation: 10ns period
   always #5 CLK <= ~CLK;
 
+  int error_count = 0;
+
   initial begin
     // Initialize signals
     CLK = 0;
@@ -79,10 +81,10 @@ module systolic_array_tb;
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue[0])
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
         assert (o_data == '0)
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -93,7 +95,7 @@ module systolic_array_tb;
       random_value = $urandom_range(0, 1024);
       enqueue(random_value);
       assert (o_data == ref_queue[0])
-      else $error("Enqueue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+      else begin error_count++; $error("Enqueue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
     end
 
     // Test Case 3: Replace nodes
@@ -103,7 +105,7 @@ module systolic_array_tb;
       random_value = $urandom_range(0, 1024);
       replace(random_value);
       assert (o_data == ref_queue[0])
-      else $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+      else begin error_count++; $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
     end
 
     // Test Case 4: Stress Test
@@ -112,13 +114,13 @@ module systolic_array_tb;
     $display("\nTest Case 4: Stress Test");
     for (int i = 0; i < 100; i++) begin
       random_value = $urandom_range(0, 1024);
-      random_operation = t_operation'($urandom_range(1,3));
+      random_operation = t_operation'($urandom_range(1, 3));  
       case (random_operation)
         ENQUEUE: begin
           enqueue(random_value);
           assert (o_data == ref_queue[0])
           else
-            $error("Enqueue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+            begin error_count++; $error("Enqueue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
         end
 
         DEQUEUE: begin
@@ -126,10 +128,10 @@ module systolic_array_tb;
           if (!o_empty) begin
             assert (o_data == ref_queue[0])
             else
-              $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+              begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
           end else begin
             assert (o_data == '0)
-            else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+            else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
 
@@ -137,7 +139,7 @@ module systolic_array_tb;
           replace(random_value);
           assert (o_data == ref_queue[0])
           else
-            $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+            begin error_count++; $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
         end
 
         default: begin
@@ -146,8 +148,13 @@ module systolic_array_tb;
       endcase
     end
 
-    $display("\nTest completed! ");
-    $finish;
+    if (error_count == 0) begin
+      $display("\nTest completed!");
+      $finish;
+    end else begin
+      $display("\n%0d error(s) detected during simulation.", error_count);
+      $fatal(1, "Test FAILED with %0d error(s).", error_count);
+    end
   end
 
   // Task to write to the end of the queue

--- a/hwpq/systolic_array/rtl/sim/systolic_array_tb.sv
+++ b/hwpq/systolic_array/rtl/sim/systolic_array_tb.sv
@@ -15,8 +15,8 @@ module systolic_array_tb;
   logic [DATA_WIDTH-1:0] i_data;
 
   // Output signals
-  logic                  o_full;
-  logic                  o_empty;
+  logic                  o_write_ready;
+  logic                  o_read_ready;
   logic [DATA_WIDTH-1:0] o_data;
 
   // Reference array for verification
@@ -43,8 +43,8 @@ module systolic_array_tb;
       .i_wrt(i_wrt),
       .i_read(i_read),
       .i_data(i_data),
-      .o_full(o_full),
-      .o_empty(o_empty),
+      .o_write_ready(o_write_ready),
+      .o_read_ready(o_read_ready),
       .o_data(o_data)
   );
 
@@ -79,7 +79,7 @@ module systolic_array_tb;
     $display("\nTest Case 1: Dequeue Test");
     for (int i = 0; i < QUEUE_SIZE; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue[0])
         else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
@@ -125,7 +125,7 @@ module systolic_array_tb;
 
         DEQUEUE: begin
           dequeue();
-          if (!o_empty) begin
+          if (o_read_ready) begin
             assert (o_data == ref_queue[0])
             else
               begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
@@ -161,7 +161,7 @@ module systolic_array_tb;
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     logic [DATA_WIDTH-1:0] tmp;
     begin
-      if (!o_full) begin
+      if (o_write_ready) begin
         i_wrt  = 1;
         i_read = 0;
         i_data = value;
@@ -191,7 +191,7 @@ module systolic_array_tb;
   // Task to read root node
   task automatic dequeue();
     begin
-      if (!o_empty) begin
+      if (o_read_ready) begin
         i_wrt  = 0;
         i_read = 1;
         for (int i = 0; i < ref_size - 1; i++) begin

--- a/hwpq/systolic_array/rtl/sim/systolic_array_tb.sv
+++ b/hwpq/systolic_array/rtl/sim/systolic_array_tb.sv
@@ -6,8 +6,8 @@ module systolic_array_tb;
   parameter int DATA_WIDTH = 16;
 
   // Clock and reset signals
-  logic                  CLK;
-  logic                  RSTn;
+  logic                  i_CLK;
+  logic                  i_RSTn;
 
   // Input signals
   logic                  i_wrt;
@@ -38,8 +38,8 @@ module systolic_array_tb;
       .QUEUE_SIZE(QUEUE_SIZE),
       .DATA_WIDTH(DATA_WIDTH)
   ) u_SystolicArray (
-      .i_CLK(CLK),
-      .i_RSTn(RSTn),
+      .i_CLK(i_CLK),
+      .i_RSTn(i_RSTn),
       .i_wrt(i_wrt),
       .i_read(i_read),
       .i_data(i_data),
@@ -49,30 +49,30 @@ module systolic_array_tb;
   );
 
   // Clock generation: 10ns period
-  always #5 CLK <= ~CLK;
+  always #5 i_CLK <= ~i_CLK;
 
   int error_count = 0;
 
   initial begin
     // Initialize signals
-    CLK = 0;
-    RSTn = 0;
+    i_CLK = 0;
+    i_RSTn = 0;
     i_wrt = 0;
     i_read = 0;
     i_data = 0;
 
     // Reset the module
-    @(posedge CLK);
-    RSTn = 1;
-    @(posedge CLK);
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    @(posedge i_CLK);
 
     // Initialize the queue, fill it up to QUEUE_SIZE with random values
     for (int i = 0; i < QUEUE_SIZE; i++) begin
       random_value = $urandom_range(0, 1024);
       enqueue(random_value);
-      repeat (5) @(posedge CLK);  // to make sure that the queue is correctly initialized
+      repeat (5) @(posedge i_CLK);  // to make sure that the queue is correctly initialized
     end
-    repeat (5) @(posedge CLK);  // wait for the queue to stabilize
+    repeat (5) @(posedge i_CLK);  // wait for the queue to stabilize
 
     // Test Case 1: Dequeue nodes
     // Dequeue nodes for QUEUE_SIZE times
@@ -181,10 +181,10 @@ module systolic_array_tb;
       end else begin
         $display("Enqueue: Queue full, skipping enqueue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (2) @(posedge CLK); 
+      repeat (2) @(posedge i_CLK); 
     end
   endtask
 
@@ -203,10 +203,10 @@ module systolic_array_tb;
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (3) @(posedge CLK);
+      repeat (3) @(posedge i_CLK);
     end
   endtask
 
@@ -232,10 +232,10 @@ module systolic_array_tb;
         $display("Replace: Queue empty, skipping replace");
       end
       
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (2) @(posedge CLK); 
+      repeat (2) @(posedge i_CLK); 
     end
   endtask
 

--- a/hwpq/systolic_array/rtl/src/systolic_array.sv
+++ b/hwpq/systolic_array/rtl/src/systolic_array.sv
@@ -1,5 +1,26 @@
 `default_nettype none
 
+/*******************************************************************************
+  Module Name: systolic_array
+  Date: 2026/06/18
+  Description: A priority queue implementation using a systolic array of an
+               input buffer (IB) and output buffer (OB). New nodes shift
+               through the IB, swapping bubble-sort style with adjacent OB
+               nodes so higher-priority (larger f) values migrate into the
+               OB; dequeuing the OB head propagates a "bubble" back through
+               the array to refill it.
+  Parameters: QUEUE_SIZE - Maximum number of elements in the priority queue
+              DATA_WIDTH - Bit width of the node's evaluation value (f)
+  Inputs: i_CLK - System clock
+          i_RSTn - Active-low reset signal
+          i_wrt - Enqueue signal
+          i_read - Dequeue signal
+          i_data - Node data input
+  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
+           o_empty - High when the queue is empty
+           o_data - Node data output (highest priority element)
+*******************************************************************************/
+
 module systolic_array #(
     parameter int QUEUE_SIZE = 4,  // Size of the buffers (number of positions)
     parameter int DATA_WIDTH = 16  // Width of the node data (evaluation function value 'f')

--- a/hwpq/systolic_array/rtl/src/systolic_array.sv
+++ b/hwpq/systolic_array/rtl/src/systolic_array.sv
@@ -16,8 +16,8 @@
           i_wrt - Enqueue signal
           i_read - Dequeue signal
           i_data - Node data input
-  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
-           o_empty - High when the queue is empty
+  Outputs: o_write_ready - High when the queue has room to accept a write
+           o_read_ready - High when the queue holds data available to read
            o_data - Node data output (highest priority element)
 *******************************************************************************/
 
@@ -34,8 +34,8 @@ module systolic_array #(
     input var logic [DATA_WIDTH-1:0]  i_data,  // Node data input
 
     // Output
-    output var logic                  o_full,   // Queue is full
-    output var logic                  o_empty,  // Queue is empty
+    output var logic                  o_write_ready,   // High if the queue can accept a write
+    output var logic                  o_read_ready,  // High if the queue has data to read
     output var logic [DATA_WIDTH-1:0] o_data    // Node data output
 );
 
@@ -61,8 +61,8 @@ module systolic_array #(
 
   assign full  = (size >= QUEUE_SIZE);
   assign empty = (size <= 0);
-  assign o_full  = full;
-  assign o_empty = empty;
+  assign o_write_ready  = !full;
+  assign o_read_ready = !empty;
   assign o_data  = OB[0];
 
   // Sequential logic

--- a/scripts/run_sim.sh
+++ b/scripts/run_sim.sh
@@ -7,7 +7,7 @@
 #   <testbench_file>  path to the testbench .sv (e.g. hwpq/register_tree/rtl/sim/register_tree_tb.sv)
 #   <top_module>      top-level module name declared in the testbench (e.g. register_tree_tb)
 #
-set -euo pipefail
+set -eu
 
 MODULE="$1"
 TB="$2"
@@ -37,13 +37,12 @@ iverilog -g2012 -Wall -s "${TOP}" -o "${BUILD}/sim.vvp" "${PKGS[@]}" "${REST[@]}
 
 echo "==> Running ${MODULE}"
 vvp "${BUILD}/sim.vvp" | tee "${LOG}"
+status="${PIPESTATUS[0]}"
 
 echo "==> Checking results for ${MODULE}"
-status=0
 
-if grep -inE 'error|mismatch|assertion|\bfail' "${LOG}"; then
-  echo "::error::${MODULE}: assertion/error output detected in simulation log"
-  status=1
+if [ "${status}" -ne 0 ]; then
+  echo "::error::${MODULE}: testbench exited with status ${status}"
 fi
 
 if ! grep -qiE 'test[[:space:]]+completed' "${LOG}"; then


### PR DESCRIPTION
Replaces o_full/o_empty we want o_write_ready/o_read_ready

Renamed ports across all tbs and srcs, inverted assignments, and updated header and inline comments

also unified i_CLK and i_RSTn port naming in preparation for potential testbench standardization