### PR TITLE
Feat/ready signals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ hwpq/register_array/rtl_elaboration/
 obj_dir
 *.vvp
 *.vcd
+
+build/

--- a/hwpq/bram_tree/rtl/sim/bram_tree_tb.sv
+++ b/hwpq/bram_tree/rtl/sim/bram_tree_tb.sv
@@ -11,8 +11,8 @@ module bram_tree_tb;
   logic   [DATA_WIDTH-1:0] i_data;
 
   // Output signals
-  logic                   o_full;
-  logic                   o_empty;
+  logic                   o_write_ready;
+  logic                   o_read_ready;
   logic   [DATA_WIDTH-1:0] o_data;
 
   // Reference array for verification
@@ -37,8 +37,8 @@ module bram_tree_tb;
       .i_wrt(i_wrt),
       .i_read(i_read),
       .i_data(i_data),
-      .o_full(o_full),
-      .o_empty(o_empty),
+      .o_write_ready(o_write_ready),
+      .o_read_ready(o_read_ready),
       .o_data(o_data)
   );
 
@@ -73,7 +73,7 @@ module bram_tree_tb;
     $display("\nTest Case 1: Dequeue Test");
     for (i = 0; i < QUEUE_SIZE; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue[0])
         else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
@@ -125,7 +125,7 @@ module bram_tree_tb;
 
         DEQUEUE: begin
           dequeue();
-          if (!o_empty) begin
+          if (o_read_ready) begin
             assert (o_data == ref_queue[0])
             else
               begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
@@ -162,7 +162,7 @@ module bram_tree_tb;
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     logic [DATA_WIDTH-1:0] tmp;
     begin
-      if (!o_full) begin
+      if (o_write_ready) begin
         i_wrt  = 1;
         i_read = 0;
         i_data = value;
@@ -192,7 +192,7 @@ module bram_tree_tb;
   // Task to read root node
   task automatic dequeue();
     begin
-      if (!o_empty) begin
+      if (o_read_ready) begin
         i_wrt  = 0;
         i_read = 1;
         for (int i = 0; i < ref_size - 1; i++) begin

--- a/hwpq/bram_tree/rtl/sim/bram_tree_tb.sv
+++ b/hwpq/bram_tree/rtl/sim/bram_tree_tb.sv
@@ -24,9 +24,9 @@ module bram_tree_tb;
   logic   [DATA_WIDTH-1:0] random_value;
 
   typedef enum integer {
-    ENQUEUE = 1,
-    DEQUEUE = 2,
-    REPLACE = 3
+    ENQUEUE = 0,
+    DEQUEUE = 1,
+    REPLACE = 2
   } operation_t;
 	operation_t random_operation;
 
@@ -61,85 +61,52 @@ module bram_tree_tb;
     repeat (2) @(posedge i_CLK);
 
     // Initialize the reference queue, sort the reference queue, and write to the queue
-    for (i = 0; i < QUEUE_SIZE; i++) begin
+    for (i = 0; i < QUEUE_SIZE*5; i++) begin
       random_value = $urandom_range(0, 1024);
       enqueue(random_value);
     end
-
-    repeat (16) @(posedge i_CLK);
 
     // Test Case 1: Dequeue nodes
     // Dequeue nodes for QUEUE_SIZE times
     $display("\nTest Case 1: Dequeue Test");
-    for (i = 0; i < QUEUE_SIZE; i++) begin
+    for (i = 0; i < QUEUE_SIZE*5; i++) begin
       dequeue();
-      if (o_read_ready) begin
-        assert (o_data == ref_queue[0])
-        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
-      end else begin
-        assert (o_data == '0)
-        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
-      end
     end
-
-    repeat (16) @(posedge i_CLK);
-
     
     // Test Case 2: Enqueue nodes
     // Enqueue random values for QUEUE_SIZE times
     $display("\nTest Case 2: Enqueue Test");
-    for (i = 0; i < QUEUE_SIZE; i++) begin
+    for (i = 0; i < QUEUE_SIZE*3; i++) begin
       random_value = $urandom_range(0, 1024);
       enqueue(random_value);
-      assert (o_data == ref_queue[0])
-      else begin error_count++; $error("Enqueue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
     end
-
-
-    repeat (16) @(posedge i_CLK);
     
     // Test Case 3: Replace nodes
     // Replace root node for QUEUE_SIZE times
     $display("\nTest Case 3: Replace Test");
-    for (i = 0; i < QUEUE_SIZE; i++) begin
+    for (i = 0; i < QUEUE_SIZE*3; i++) begin
       random_value = $urandom_range(0, 1024);
       replace(random_value);
-      assert (o_data == ref_queue[0])
-      else begin error_count++; $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
     end
 
     
     // Test Case 3: Stress Test
     // stress test, mix operations
     $display("\nTest Case 4: Stress Test");
-    for (i = 0; i < 100; i++) begin
+    for (i = 0; i < 1000; i++) begin
       random_value = $urandom_range(0, 1024);
-      random_operation = operation_t'($urandom_range(1,3));
+      random_operation = operation_t'($urandom_range(0,2));
       case (random_operation)
 				ENQUEUE: begin
           enqueue(random_value);
-          assert (o_data == ref_queue[0])
-          else
-            begin error_count++; $error("Enqueue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
         end
 
         DEQUEUE: begin
           dequeue();
-          if (o_read_ready) begin
-            assert (o_data == ref_queue[0])
-            else
-              begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
-          end else begin
-            assert (o_data == '0)
-            else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
-          end
         end
 
         REPLACE: begin
           replace(random_value);
-          assert (o_data == ref_queue[0])
-          else
-            begin error_count++; $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
         end
 
         default: begin
@@ -180,12 +147,10 @@ module bram_tree_tb;
           end
         end
       end else begin
-        $display("Enqueue: Queue full, skipping enqueue");
+        i_wrt  = 0;
+        i_read = 0;
       end
       @(posedge i_CLK);
-      i_wrt  = 0;
-      i_read = 0;
-      repeat (6 * ($clog2(QUEUE_SIZE + 1) + 1)) @(posedge i_CLK);
     end
   endtask
 
@@ -193,6 +158,9 @@ module bram_tree_tb;
   task automatic dequeue();
     begin
       if (o_read_ready) begin
+        assert (o_data == ref_queue[0])
+        else
+          begin error_count++; $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
         i_wrt  = 0;
         i_read = 1;
         for (int i = 0; i < ref_size - 1; i++) begin
@@ -202,12 +170,10 @@ module bram_tree_tb;
         ref_size--;
         
       end else begin
-        $display("Dequeue: Queue empty, skipping dequeue");
+        i_wrt  = 0;
+        i_read = 0;
       end
       @(posedge i_CLK);
-      i_wrt  = 0;
-      i_read = 0;
-      repeat (6 * ($clog2(QUEUE_SIZE + 1) + 1)) @(posedge i_CLK);
     end
   endtask
 
@@ -215,7 +181,10 @@ module bram_tree_tb;
   task automatic replace(input logic [DATA_WIDTH-1:0] value);
     logic [DATA_WIDTH-1:0] tmp;
     begin
-      if (ref_size > 0) begin
+      if (o_read_ready) begin
+        assert (o_data == ref_queue[0])
+        else
+          begin error_count++; $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
         i_wrt  = 1;
         i_read = 1;
         i_data = value;
@@ -230,13 +199,10 @@ module bram_tree_tb;
           end
         end
       end else begin
-        $display("Replace: Queue empty, skipping replace");
+        i_wrt  = 0;
+        i_read = 0;
       end
-      
       @(posedge i_CLK);
-      i_wrt  = 0;
-      i_read = 0;
-      repeat (6 * ($clog2(QUEUE_SIZE + 1) + 1)) @(posedge i_CLK);
     end
   endtask
 

--- a/hwpq/bram_tree/rtl/sim/bram_tree_tb.sv
+++ b/hwpq/bram_tree/rtl/sim/bram_tree_tb.sv
@@ -45,6 +45,8 @@ module bram_tree_tb;
   // Clock generation: 10ns period
   always #5 CLK <= ~CLK;
 
+  int error_count = 0;
+
   initial begin
     // Initialize signals
     CLK = 0;
@@ -73,10 +75,10 @@ module bram_tree_tb;
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue[0])
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
         assert (o_data == '0)
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -90,7 +92,7 @@ module bram_tree_tb;
       random_value = $urandom_range(0, 1024);
       enqueue(random_value);
       assert (o_data == ref_queue[0])
-      else $error("Enqueue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+      else begin error_count++; $error("Enqueue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
     end
 
 
@@ -103,7 +105,7 @@ module bram_tree_tb;
       random_value = $urandom_range(0, 1024);
       replace(random_value);
       assert (o_data == ref_queue[0])
-      else $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+      else begin error_count++; $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
     end
 
     
@@ -118,7 +120,7 @@ module bram_tree_tb;
           enqueue(random_value);
           assert (o_data == ref_queue[0])
           else
-            $error("Enqueue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+            begin error_count++; $error("Enqueue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
         end
 
         DEQUEUE: begin
@@ -126,10 +128,10 @@ module bram_tree_tb;
           if (!o_empty) begin
             assert (o_data == ref_queue[0])
             else
-              $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+              begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
           end else begin
             assert (o_data == '0)
-            else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+            else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
 
@@ -137,7 +139,7 @@ module bram_tree_tb;
           replace(random_value);
           assert (o_data == ref_queue[0])
           else
-            $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+            begin error_count++; $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
         end
 
         default: begin
@@ -147,8 +149,13 @@ module bram_tree_tb;
     end
     
 
-    $display("\nTest completed! ");
-    $finish;
+    if (error_count == 0) begin
+      $display("\nTest completed!");
+      $finish;
+    end else begin
+      $display("\n%0d error(s) detected during simulation.", error_count);
+      $fatal(1, "Test FAILED with %0d error(s).", error_count);
+    end
   end
 
   // Task to write to the end of the queue

--- a/hwpq/bram_tree/rtl/sim/bram_tree_tb.sv
+++ b/hwpq/bram_tree/rtl/sim/bram_tree_tb.sv
@@ -45,6 +45,23 @@ module bram_tree_tb;
   // Clock generation: 10ns period
   always #5 i_CLK <= ~i_CLK;
 
+  logic settled;
+  assign settled = o_write_ready || o_read_ready;
+
+  localparam int SETTLE_TIMEOUT = 10000;
+  task automatic poll_settled();
+    int guard;
+    guard = 0;
+    while (!settled) begin
+      @(negedge i_CLK);
+      guard++;
+      if (guard > SETTLE_TIMEOUT) begin
+        $fatal(1, "poll_settled: DUT never settled after %0d cycles (o_write_ready=%0b o_read_ready=%0b)",
+               SETTLE_TIMEOUT, o_write_ready, o_read_ready);
+      end
+    end
+  endtask
+
   int error_count = 0;
 
   initial begin
@@ -59,14 +76,14 @@ module bram_tree_tb;
     @(posedge i_CLK);
     i_RSTn = 1;
     repeat (2) @(posedge i_CLK);
-
+    @(negedge i_CLK);
     // Initialize the reference queue, sort the reference queue, and write to the queue
     for (i = 0; i < QUEUE_SIZE; i++) begin
       random_value = $urandom_range(0, 1024);
       enqueue(random_value);
     end
 
-    repeat (16) @(posedge i_CLK);
+    poll_settled();
 
     // Test Case 1: Dequeue nodes
     // Dequeue nodes for QUEUE_SIZE times
@@ -82,7 +99,7 @@ module bram_tree_tb;
       end
     end
 
-    repeat (16) @(posedge i_CLK);
+    poll_settled();
 
     
     // Test Case 2: Enqueue nodes
@@ -96,7 +113,7 @@ module bram_tree_tb;
     end
 
 
-    repeat (16) @(posedge i_CLK);
+    poll_settled();
     
     // Test Case 3: Replace nodes
     // Replace root node for QUEUE_SIZE times
@@ -162,6 +179,7 @@ module bram_tree_tb;
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     logic [DATA_WIDTH-1:0] tmp;
     begin
+      poll_settled();
       if (o_write_ready) begin
         i_wrt  = 1;
         i_read = 0;
@@ -183,15 +201,17 @@ module bram_tree_tb;
         $display("Enqueue: Queue full, skipping enqueue");
       end
       @(posedge i_CLK);
+      @(negedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (6 * ($clog2(QUEUE_SIZE + 1) + 1)) @(posedge i_CLK);
+      poll_settled();
     end
   endtask
 
   // Task to read root node
   task automatic dequeue();
     begin
+      poll_settled();
       if (o_read_ready) begin
         i_wrt  = 0;
         i_read = 1;
@@ -205,9 +225,10 @@ module bram_tree_tb;
         $display("Dequeue: Queue empty, skipping dequeue");
       end
       @(posedge i_CLK);
+      @(negedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (6 * ($clog2(QUEUE_SIZE + 1) + 1)) @(posedge i_CLK);
+      poll_settled();
     end
   endtask
 
@@ -215,6 +236,7 @@ module bram_tree_tb;
   task automatic replace(input logic [DATA_WIDTH-1:0] value);
     logic [DATA_WIDTH-1:0] tmp;
     begin
+      poll_settled();
       if (ref_size > 0) begin
         i_wrt  = 1;
         i_read = 1;
@@ -234,9 +256,10 @@ module bram_tree_tb;
       end
       
       @(posedge i_CLK);
+      @(negedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (6 * ($clog2(QUEUE_SIZE + 1) + 1)) @(posedge i_CLK);
+      poll_settled();
     end
   endtask
 

--- a/hwpq/bram_tree/rtl/sim/bram_tree_tb.sv
+++ b/hwpq/bram_tree/rtl/sim/bram_tree_tb.sv
@@ -2,8 +2,8 @@ import bram_tree_pkg::*;
 
 module bram_tree_tb;
   // Clock and reset signals
-  logic                   CLK;
-  logic                   RSTn;
+  logic                   i_CLK;
+  logic                   i_RSTn;
 
   // Input signals
   logic                   i_wrt;
@@ -32,8 +32,8 @@ module bram_tree_tb;
 
   // Instantiate the register_tree module
   bram_tree uut (
-      .CLK(CLK),
-      .RSTn(RSTn),
+      .i_CLK(i_CLK),
+      .i_RSTn(i_RSTn),
       .i_wrt(i_wrt),
       .i_read(i_read),
       .i_data(i_data),
@@ -43,22 +43,22 @@ module bram_tree_tb;
   );
 
   // Clock generation: 10ns period
-  always #5 CLK <= ~CLK;
+  always #5 i_CLK <= ~i_CLK;
 
   int error_count = 0;
 
   initial begin
     // Initialize signals
-    CLK = 0;
-    RSTn = 0;
+    i_CLK = 0;
+    i_RSTn = 0;
     i_wrt = 0;
     i_read = 0;
     i_data = 0;
 
     // Reset the module
-    @(posedge CLK);
-    RSTn = 1;
-    repeat (2) @(posedge CLK);
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    repeat (2) @(posedge i_CLK);
 
     // Initialize the reference queue, sort the reference queue, and write to the queue
     for (i = 0; i < QUEUE_SIZE; i++) begin
@@ -66,7 +66,7 @@ module bram_tree_tb;
       enqueue(random_value);
     end
 
-    repeat (16) @(posedge CLK);
+    repeat (16) @(posedge i_CLK);
 
     // Test Case 1: Dequeue nodes
     // Dequeue nodes for QUEUE_SIZE times
@@ -82,7 +82,7 @@ module bram_tree_tb;
       end
     end
 
-    repeat (16) @(posedge CLK);
+    repeat (16) @(posedge i_CLK);
 
     
     // Test Case 2: Enqueue nodes
@@ -96,7 +96,7 @@ module bram_tree_tb;
     end
 
 
-    repeat (16) @(posedge CLK);
+    repeat (16) @(posedge i_CLK);
     
     // Test Case 3: Replace nodes
     // Replace root node for QUEUE_SIZE times
@@ -182,10 +182,10 @@ module bram_tree_tb;
       end else begin
         $display("Enqueue: Queue full, skipping enqueue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (6 * ($clog2(QUEUE_SIZE + 1) + 1)) @(posedge CLK);
+      repeat (6 * ($clog2(QUEUE_SIZE + 1) + 1)) @(posedge i_CLK);
     end
   endtask
 
@@ -204,10 +204,10 @@ module bram_tree_tb;
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (6 * ($clog2(QUEUE_SIZE + 1) + 1)) @(posedge CLK);
+      repeat (6 * ($clog2(QUEUE_SIZE + 1) + 1)) @(posedge i_CLK);
     end
   endtask
 
@@ -233,10 +233,10 @@ module bram_tree_tb;
         $display("Replace: Queue empty, skipping replace");
       end
       
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (6 * ($clog2(QUEUE_SIZE + 1) + 1)) @(posedge CLK);
+      repeat (6 * ($clog2(QUEUE_SIZE + 1) + 1)) @(posedge i_CLK);
     end
   endtask
 

--- a/hwpq/bram_tree/rtl/src/bram_tree.sv
+++ b/hwpq/bram_tree/rtl/src/bram_tree.sv
@@ -1,7 +1,7 @@
 /*******************************************************************************
   Module Name: bram_tree
   Date: 2025/03/05
-  Description: A priority queue implementation using a binary min-heap structure
+  Description: A priority queue implementation using a binary max-heap structure
                stored in block RAM (BRAM). Supports enqueue, dequeue, and replace
                operations.
   Parameters: QUEUE_SIZE - Maximum number of elements in the priority queue
@@ -14,7 +14,6 @@
   Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
            o_empty - High when the queue is empty
            o_data - Output data from the highest priority element
-           o_ready - High if the tree is done propagating/rebalancing & ready for another read/write
 *******************************************************************************/
 
 package bram_tree_pkg;

--- a/hwpq/bram_tree/rtl/src/bram_tree.sv
+++ b/hwpq/bram_tree/rtl/src/bram_tree.sv
@@ -11,8 +11,8 @@
           i_wrt - Write/insert command (enqueue operation)
           i_read - Read/pop command (dequeue operation)
           i_data - Input data to be enqueued
-  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
-           o_empty - High when the queue is empty
+  Outputs: o_write_ready - High when the queue has room to accept a write
+           o_read_ready - High when the queue holds data available to read
            o_data - Output data from the highest priority element
 *******************************************************************************/
 
@@ -48,8 +48,8 @@ module bram_tree #(
     input  logic                  i_read,   // Read/pop command
     input  logic [DATA_WIDTH-1:0] i_data,   // Input data
     // Outputs
-    output logic                  o_full,   // High if the heap is full
-    output logic                  o_empty,  // High if the heap is empty
+    output logic                  o_write_ready,   // High if the queue can accept a write
+    output logic                  o_read_ready,  // High if the queue has data to read
     output logic [DATA_WIDTH-1:0] o_data    // Output data (Root node)
 );
 
@@ -158,7 +158,7 @@ module bram_tree #(
 
     case (state)
       IDLE: begin
-        if (i_wrt && !i_read && !o_full) begin // --- ENQUEUE ---
+        if (i_wrt && !i_read && o_write_ready) begin // --- ENQUEUE ---
           if (queue_size == 0) begin
             addr_a = 0;
             we_a = 1;
@@ -178,7 +178,7 @@ module bram_tree #(
             next_state = ENQUEUE_COMPARE_ROOT;
           end
           next_queue_size = queue_size + 1;
-        end else if (!i_wrt && i_read && !o_empty) begin // --- DEQUEUE ---
+        end else if (!i_wrt && i_read && o_read_ready) begin // --- DEQUEUE ---
           addr_a = 0;
           we_a = 1;
 
@@ -682,8 +682,8 @@ module bram_tree #(
     endcase
   end
 
-  assign o_full  = (queue_size == QUEUE_SIZE);
-  assign o_empty = (queue_size == 0);
+  assign o_write_ready  = !(queue_size == QUEUE_SIZE);
+  assign o_read_ready = !(queue_size == 0);
   assign o_data  = (queue_size == 0) ? 0 : out_reg;
   assign ready   = (state == IDLE);
 endmodule

--- a/hwpq/bram_tree/rtl/src/bram_tree.sv
+++ b/hwpq/bram_tree/rtl/src/bram_tree.sv
@@ -6,8 +6,8 @@
                operations.
   Parameters: QUEUE_SIZE - Maximum number of elements in the priority queue
               DATA_WIDTH - Bit width of data elements
-  Inputs: CLK - System clock
-          RSTn - Active-low reset signal
+  Inputs: i_CLK - System clock
+          i_RSTn - Active-low reset signal
           i_wrt - Write/insert command (enqueue operation)
           i_read - Read/pop command (dequeue operation)
           i_data - Input data to be enqueued
@@ -41,8 +41,8 @@ module bram_tree #(
 		parameter integer QUEUE_SIZE = bram_tree_pkg::QUEUE_SIZE,
     parameter integer DATA_WIDTH = bram_tree_pkg::DATA_WIDTH
 )(
-    input  logic                  CLK,
-    input  logic                  RSTn,
+    input  logic                  i_CLK,
+    input  logic                  i_RSTn,
     // Inputs
     input  logic                  i_wrt,    // Write/insert command
     input  logic                  i_read,   // Read/pop command
@@ -110,12 +110,12 @@ module bram_tree #(
   logic [DATA_WIDTH-1:0] second_greatest, next_second_greatest;
 
   rams_tdp_rf_rf bram_inst (
-    .clka (CLK), .ena(1'b1), .wea(we_a), .addra(addr_a), .dia(din_a), .doa(dout_a),
-    .clkb (CLK), .enb(1'b1), .web(we_b), .addrb(addr_b), .dib(din_b), .dob(dout_b)
+    .clka (i_CLK), .ena(1'b1), .wea(we_a), .addra(addr_a), .dia(din_a), .doa(dout_a),
+    .clkb (i_CLK), .enb(1'b1), .web(we_b), .addrb(addr_b), .dib(din_b), .dob(dout_b)
   );
 
-  always_ff @(posedge CLK or negedge RSTn) begin : fsm_seq
-    if (!RSTn) begin
+  always_ff @(posedge i_CLK or negedge i_RSTn) begin : fsm_seq
+    if (!i_RSTn) begin
       state         <= IDLE;
       queue_size    <= 0;
       curr          <= '0;

--- a/hwpq/bram_tree/rtl/src/bram_tree.sv
+++ b/hwpq/bram_tree/rtl/src/bram_tree.sv
@@ -682,8 +682,10 @@ module bram_tree #(
     endcase
   end
 
-  assign o_write_ready  = !(queue_size == QUEUE_SIZE);
-  assign o_read_ready = !(queue_size == 0);
-  assign o_data  = (queue_size == 0) ? 0 : out_reg;
+  // Both ports gate on the same term since this is a single-threaded FSM
+  // the IDLE state already exposes a usable ready signal
   assign ready   = (state == IDLE);
+  assign o_write_ready = !(queue_size == QUEUE_SIZE) && ready;
+  assign o_read_ready  = !(queue_size == 0) && ready;
+  assign o_data  = (queue_size == 0) ? 0 : out_reg;
 endmodule

--- a/hwpq/bram_tree/rtl/src/bram_tree.sv
+++ b/hwpq/bram_tree/rtl/src/bram_tree.sv
@@ -1,3 +1,22 @@
+/*******************************************************************************
+  Module Name: bram_tree
+  Date: 2025/03/05
+  Description: A priority queue implementation using a binary min-heap structure
+               stored in block RAM (BRAM). Supports enqueue, dequeue, and replace
+               operations.
+  Parameters: QUEUE_SIZE - Maximum number of elements in the priority queue
+              DATA_WIDTH - Bit width of data elements
+  Inputs: CLK - System clock
+          RSTn - Active-low reset signal
+          i_wrt - Write/insert command (enqueue operation)
+          i_read - Read/pop command (dequeue operation)
+          i_data - Input data to be enqueued
+  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
+           o_empty - High when the queue is empty
+           o_data - Output data from the highest priority element
+           o_ready - High if the tree is done propagating/rebalancing & ready for another read/write
+*******************************************************************************/
+
 package bram_tree_pkg;
   localparam integer DATA_WIDTH = 16;
   localparam integer QUEUE_SIZE = 7;

--- a/hwpq/bram_tree/rtl/src/bram_tree.sv
+++ b/hwpq/bram_tree/rtl/src/bram_tree.sv
@@ -14,13 +14,27 @@
   Outputs: o_write_ready - High when the queue has room to accept a write
            o_read_ready - High when the queue holds data available to read
            o_data - Output data from the highest priority element
+
+  Cleanup notes (relative to original):
+    - Removed parent_idx and the parent/left_child/right_child registers
+      (next_state logic never wrote or read them).
+    - Removed three unreachable states: ENQUEUE_COMPARE_ROOT,
+      DEQUEUE_READ_ROOT_CHILDREN, REPLACE_READ_ROOT.
+    - Factored the repeated "are we past the last valid child / are both
+      children inactive" checks into children_out_of_range and
+      both_children_inactive.
+    - Factored the repeated "(state == IDLE) && !(i_read || i_wrt)" term
+      used by all three ready/valid outputs into idle_and_no_new_request.
+    - Replaced all `'{field: value, ...}` assignment-pattern struct literals
+      with field-by-field assignment (next.value = ...; next.position = ...;
+      etc.) for Icarus Verilog compatibility. Plain '0 fills are unaffected.
 *******************************************************************************/
 
 package bram_tree_pkg;
   localparam integer DATA_WIDTH = 16;
   localparam integer QUEUE_SIZE = 7;
   localparam integer TREE_DEPTH    = $clog2(QUEUE_SIZE + 1);
-  localparam integer NODES_NEEDED  = (1 << TREE_DEPTH) - 1; 
+  localparam integer NODES_NEEDED  = (1 << TREE_DEPTH) - 1;
   localparam integer ADDRESS_WIDTH = $clog2(NODES_NEEDED);
 
   // Define your structs here so all modules can see them
@@ -37,10 +51,9 @@ package bram_tree_pkg;
   } bram_tree_curr_t;
 endpackage
 
-module bram_tree #(
-		parameter integer QUEUE_SIZE = bram_tree_pkg::QUEUE_SIZE,
-    parameter integer DATA_WIDTH = bram_tree_pkg::DATA_WIDTH
-)(
+import bram_tree_pkg::*;
+
+module bram_tree (
     input  logic                  i_CLK,
     input  logic                  i_RSTn,
     // Inputs
@@ -48,50 +61,37 @@ module bram_tree #(
     input  logic                  i_read,   // Read/pop command
     input  logic [DATA_WIDTH-1:0] i_data,   // Input data
     // Outputs
-    output logic                  o_write_ready,   // High if the queue can accept a write
-    output logic                  o_read_ready,  // High if the queue has data to read
-    output logic [DATA_WIDTH-1:0] o_data    // Output data (Root node)
+    output logic                  o_write_ready,   // High if the heap is full
+    output logic                  o_read_ready,  // High if the heap is empty
+    output logic [DATA_WIDTH-1:0] o_data   // Output data (Root node)
 );
 
-  import bram_tree_pkg::*;
-
   typedef enum logic [3:0] {
-    IDLE                       = 4'd0,
-    // Enqueue 
-    ENQUEUE_COMPARE_ROOT    = 4'd1,
-    ENQUEUE_READ_CHILD      = 4'd2,
-    ENQUEUE_COMPARE_CHILD   = 4'd3,
+    IDLE                    = 4'd0,
+    // Enqueue
+    ENQUEUE_READ_CHILD      = 4'd1,
+    ENQUEUE_COMPARE_CHILD   = 4'd2,
     // Dequeue
-    DEQUEUE_READ_ROOT_CHILDREN = 4'd4,
-    DEQUEUE_COMPARE_ROOT    = 4'd5,
-    DEQUEUE_READ_CHILD      = 4'd6,
-    DEQUEUE_COMPARE_CHILD   = 4'd7,
+    DEQUEUE_COMPARE_ROOT    = 4'd3,
+    DEQUEUE_READ_CHILD      = 4'd4,
+    DEQUEUE_COMPARE_CHILD   = 4'd5,
     // Replace
-    REPLACE_READ_ROOT    = 4'd8,
-    REPLACE_COMPARE_ROOT = 4'd9,
-    REPLACE_READ_CHILD   = 4'd10,
-    REPLACE_COMPARE_CHILD = 4'd11
+    REPLACE_COMPARE_ROOT    = 4'd6,
+    REPLACE_READ_CHILD      = 4'd7,
+    REPLACE_COMPARE_CHILD   = 4'd8
   } state_t;
-
-  // Keep track if the node is active, it's value and how much available nodes are under it
-  typedef struct packed {
-    logic active;
-    logic [DATA_WIDTH-1:0] value;
-    logic [ADDRESS_WIDTH-1:0]  capacity;
-  } bram_tree_mem_t;
-
-  // Keep track of the current node's value and position
-  typedef struct packed {
-    logic [DATA_WIDTH-1:0] value;
-    logic [ADDRESS_WIDTH-1:0] position;
-    logic [ADDRESS_WIDTH-1:0] capacity;
-  } bram_tree_curr_t;
 
   state_t state, next_state;
   bram_tree_curr_t curr, next;
-  logic [ADDRESS_WIDTH:0] parent_idx, child_idx_left, child_idx_right;
+  bram_tree_mem_t  top_level, next_top_level;
+  logic [ADDRESS_WIDTH:0] child_idx_left, child_idx_right;
   integer queue_size, next_queue_size;
-  logic ready;
+  logic empty;
+
+  logic children_out_of_range;
+  logic both_children_inactive;
+  logic idle_and_no_new_request;
+
 
   // BRAM signals
   logic [ADDRESS_WIDTH-1:0] addr_a;
@@ -103,12 +103,6 @@ module bram_tree #(
   bram_tree_mem_t     dout_a;
   bram_tree_mem_t     dout_b;
 
-  logic [DATA_WIDTH-1:0] parent,     next_parent;
-  logic [DATA_WIDTH-1:0] left_child,  next_left_child;
-  logic [DATA_WIDTH-1:0] right_child, next_right_child;
-  logic [DATA_WIDTH-1:0] out_reg, next_out_reg;
-  logic [DATA_WIDTH-1:0] second_greatest, next_second_greatest;
-
   rams_tdp_rf_rf bram_inst (
     .clka (i_CLK), .ena(1'b1), .wea(we_a), .addra(addr_a), .dia(din_a), .doa(dout_a),
     .clkb (i_CLK), .enb(1'b1), .web(we_b), .addrb(addr_b), .dib(din_b), .dob(dout_b)
@@ -116,126 +110,102 @@ module bram_tree #(
 
   always_ff @(posedge i_CLK or negedge i_RSTn) begin : fsm_seq
     if (!i_RSTn) begin
-      state         <= IDLE;
-      queue_size    <= 0;
-      curr          <= '0;
-      parent        <= '0;
-      left_child    <= '0;
-      right_child   <= '0;
-      out_reg       <= '0;
-      second_greatest <= '0;
+      state      <= IDLE;
+      queue_size <= 0;
+      curr       <= '0;
+      top_level.active   <= 1'b0;
+      top_level.value    <= '0;
+      top_level.capacity <= QUEUE_SIZE;
     end else begin
-      state         <= next_state;
-      queue_size    <= next_queue_size;
-      curr          <= next;
-      parent        <= next_parent;
-      left_child    <= next_left_child;
-      right_child   <= next_right_child;
-      out_reg       <= next_out_reg;
-      second_greatest <= next_second_greatest;
+      state      <= next_state;
+      queue_size <= next_queue_size;
+      curr       <= next;
+      top_level  <= next_top_level;
     end
   end
 
   always @* begin : fsm_comb
-    next_state       = state;
-    next_queue_size  = queue_size;
-    next             = curr;
-    addr_a = 1'b0;
-    addr_b = 1'b0;
-    din_a = '0;
-    din_b = '0;
-    we_a        = 1'b0;
-    we_b        = 1'b0;
-    next_parent      = parent;
-    next_left_child  = left_child;
-    next_right_child = right_child;
-    next_out_reg     = out_reg;
-    next_second_greatest = second_greatest;
+    next_state      = state;
+    next_queue_size = queue_size;
+    next            = curr;
+    addr_a = '0;
+    addr_b = '0;
+    din_a  = '0;
+    din_b  = '0;
+    we_a   = 1'b0;
+    we_b   = 1'b0;
+    next_top_level = top_level;
 
-    parent_idx = (curr.position - 1) >> 1;
     child_idx_left  = curr.position * 2 + 1;
     child_idx_right = curr.position * 2 + 2;
 
+    children_out_of_range  = (child_idx_left > QUEUE_SIZE) || (child_idx_right > QUEUE_SIZE);
+    both_children_inactive = !dout_a.active && !dout_b.active;
+
     case (state)
       IDLE: begin
-        if (i_wrt && !i_read && o_write_ready) begin // --- ENQUEUE ---
+        if (i_wrt && !i_read) begin // --- ENQUEUE ---
           if (queue_size == 0) begin
-            addr_a = 0;
-            we_a = 1;
-
-            din_a.active   = 1'b1;
-            din_a.value    = i_data;
-            din_a.capacity = QUEUE_SIZE - 1;
-
-            next_out_reg = i_data;
+            next_top_level.active   = 1'b1;
+            next_top_level.value    = i_data;
+            next_top_level.capacity = QUEUE_SIZE - 1;
             next_state = IDLE;
           end else begin
-            next.value    = i_data;
-            next.position = 0;
-            next.capacity = 'x;
+            if(i_data > top_level.value) begin
+              next_top_level.active   = 1'b1;
+              next_top_level.value    = i_data;
+              next_top_level.capacity = top_level.capacity - 1;
 
-            addr_a = 0;
-            next_state = ENQUEUE_COMPARE_ROOT;
+              next.value    = top_level.value;
+              next.position = '0;
+              next.capacity = top_level.capacity - 1;
+            end else begin
+              next_top_level.active   = 1'b1;
+              next_top_level.value    = top_level.value;
+              next_top_level.capacity = top_level.capacity - 1;
+
+              next.value    = i_data;
+              next.position = 0;
+              next.capacity = top_level.capacity - 1;
+            end
+            addr_a = 1;
+            addr_b = 2;
+            next_state = ENQUEUE_COMPARE_CHILD;
           end
           next_queue_size = queue_size + 1;
-        end else if (!i_wrt && i_read && o_read_ready) begin // --- DEQUEUE ---
-          addr_a = 0;
-          we_a = 1;
+        end else if (!i_wrt && i_read) begin // --- DEQUEUE ---
+          next_top_level.active   = 1'b0;
+          next_top_level.value    = '0;
+          next_top_level.capacity = top_level.capacity + 1;
 
-          din_a.active   = 1'b0;
-          din_a.value    = second_greatest;
-          din_a.capacity = 'x;
+          next.value    = '0;
+          next.position = 0;
+          next.capacity = top_level.capacity + 1;
 
-          next.value   = 1'b0;
-          next.position    = '0;
-          next.capacity = 'x;
-
-          next_out_reg = second_greatest; //tentatively set it to be second greatest
+          addr_a = 1;
+          addr_b = 2;
           next_queue_size = queue_size - 1;
-          next_state = DEQUEUE_READ_ROOT_CHILDREN;
+          next_state = DEQUEUE_COMPARE_ROOT;
         end else if (i_wrt && i_read) begin // --- REPLACE ---
-
-          next.position   = 1'b0;
           next.value    = i_data;
-          next.capacity = 'x;
+          next.position = 0;
+          next.capacity = (empty) ? top_level.capacity + 1 : top_level.capacity;
 
-          next_out_reg = i_data;
-          next_state = REPLACE_READ_ROOT;
-          next_queue_size = queue_size;
+          if (queue_size == 0) begin
+            next_top_level.active   = 1'b1;
+            next_top_level.value    = i_data;
+            next_top_level.capacity = top_level.capacity + 1;
+            next_state = IDLE;
+          end else begin
+            next_top_level.active   = 1'b0;
+            next_top_level.value    = '0;
+            next_top_level.capacity = top_level.capacity;
+            next_state = REPLACE_COMPARE_ROOT;
+          end
+          addr_a = 1;
+          addr_b = 2;
+          next_queue_size = (empty) ? queue_size + 1 : queue_size;
         end
-      end
-
-      ENQUEUE_COMPARE_ROOT: begin
-        //swap here, then continue writing down the heap
-        if (curr.value > dout_a.value) begin
-          addr_a = curr.position;
-          we_a = 1;
-
-          din_a.active   = 1'b1;
-          din_a.value    = i_data;
-          din_a.capacity = dout_a.capacity - 1;
-
-          next.value    = dout_a.value;
-          next.position = '0;
-          next.capacity = dout_a.capacity - 1;
-
-          next_out_reg = curr.value;
-          next_second_greatest = dout_a.value;
-        end else begin
-          addr_a = curr.position;
-          we_a = 1;
-
-          din_a.active   = 1'b1;
-          din_a.value    = dout_a.value;
-          din_a.capacity = dout_a.capacity - 1;
-
-          next.value    = curr.value;
-          next.position = '0;
-          next.capacity = dout_a.capacity - 1;
-
-          next_out_reg = dout_a.value;
-        end
-        next_state = ENQUEUE_READ_CHILD;
       end
 
       ENQUEUE_READ_CHILD: begin
@@ -251,29 +221,22 @@ module bram_tree #(
           //Write into left
           addr_a = child_idx_left;
           we_a   = 1;
-
           din_a.active   = 1'b1;
           din_a.value    = curr.value;
           din_a.capacity = dout_a.capacity - 1;
-
-          if (curr.value > second_greatest) next_second_greatest = curr.value;
           next_state = IDLE;
         end else if (!dout_b.active && (dout_b.capacity > 0)) begin
           //Write into right
           addr_b = child_idx_right;
           we_b   = 1;
-
           din_b.active   = 1'b1;
           din_b.value    = curr.value;
           din_b.capacity = dout_b.capacity - 1;
-
-          if (curr.value > second_greatest) next_second_greatest = curr.value;
           next_state = IDLE;
         end else if (dout_a.active && (dout_a.capacity > 0) && (curr.value <= dout_a.value)) begin
           // Check children of left next
           addr_a = child_idx_left;
           we_a   = 1;
-
           din_a.active   = 1'b1;
           din_a.value    = dout_a.value;
           din_a.capacity = dout_a.capacity - 1;
@@ -281,14 +244,11 @@ module bram_tree #(
           next.value    = curr.value;
           next.position = child_idx_left;
           next.capacity = dout_a.capacity - 1;
-
-          if (dout_a.value > second_greatest) next_second_greatest = dout_a.value;
-          next_state = ENQUEUE_READ_CHILD; 
+          next_state = ENQUEUE_READ_CHILD;
         end else if (dout_b.active && (dout_b.capacity > 0) && (curr.value <= dout_b.value)) begin
           // Check children of right next
           addr_b = child_idx_right;
           we_b   = 1;
-
           din_b.active   = 1'b1;
           din_b.value    = dout_b.value;
           din_b.capacity = dout_b.capacity - 1;
@@ -296,14 +256,11 @@ module bram_tree #(
           next.value    = curr.value;
           next.position = child_idx_right;
           next.capacity = dout_b.capacity - 1;
-
-          if (dout_b.value > second_greatest) next_second_greatest = dout_b.value;
-          next_state = ENQUEUE_READ_CHILD; 
+          next_state = ENQUEUE_READ_CHILD;
         end else if (dout_a.active && (dout_a.capacity > 0) && (curr.value > dout_a.value) && ((dout_a.value <= dout_b.value) || (dout_b.capacity == 0))) begin
           //swap Left and Curr, check children of right
           addr_a = child_idx_left;
           we_a   = 1;
-
           din_a.active   = 1'b1;
           din_a.value    = curr.value;
           din_a.capacity = dout_a.capacity - 1;
@@ -311,14 +268,11 @@ module bram_tree #(
           next.value    = dout_a.value;
           next.position = child_idx_left;
           next.capacity = dout_a.capacity - 1;
-
-          if (curr.value > second_greatest) next_second_greatest = curr.value;
-          next_state = ENQUEUE_READ_CHILD; 
+          next_state = ENQUEUE_READ_CHILD;
         end else if (dout_b.active && (dout_b.capacity > 0) && (curr.value > dout_b.value) && ((dout_a.value > dout_b.value) || (dout_a.capacity == 0))) begin
           //swap Right and Curr, check children of left
           addr_b = child_idx_right;
           we_b   = 1;
-          
           din_b.active   = 1'b1;
           din_b.value    = curr.value;
           din_b.capacity = dout_b.capacity - 1;
@@ -326,47 +280,22 @@ module bram_tree #(
           next.value    = dout_b.value;
           next.position = child_idx_right;
           next.capacity = dout_b.capacity - 1;
-
-          if (curr.value > second_greatest) next_second_greatest = curr.value;
-          next_state = ENQUEUE_READ_CHILD; 
+          next_state = ENQUEUE_READ_CHILD;
         end
       end
 
-      DEQUEUE_READ_ROOT_CHILDREN: begin
-        //read nodes 1 and 2
-        next.value    = '0;
-        next.position = 0;
-        next.capacity = dout_a.capacity + 1;
-
-        addr_a = child_idx_left;
-        addr_b = child_idx_right;
-        next_state = DEQUEUE_COMPARE_ROOT;
-      end
-
       DEQUEUE_COMPARE_ROOT: begin
-        //if both nodes are inactive or we are at the end, we go to idle next, because this is root, we set the next max out
-        if ((!dout_a.active && !dout_b.active) || (child_idx_left > QUEUE_SIZE) || (child_idx_right > QUEUE_SIZE)) begin
-          addr_a = curr.position;
-          we_a = 1;
-          
-          din_a.active   = 1'b0;
-          din_a.value    = '0;
-          din_a.capacity = QUEUE_SIZE;
-          
+        //if both nodes are inactive or we are past the end, this is root: reset next max out
+        if (both_children_inactive || children_out_of_range) begin
+          next_top_level.active   = 1'b0;
+          next_top_level.value    = '0;
+          next_top_level.capacity = QUEUE_SIZE;
           next_state = IDLE;
         end else begin
           // if only one is inactive we pull that value
           if (dout_a.active && !dout_b.active) begin
-            addr_a = curr.position;
-            we_a = 1;
-            
-            din_a.active   = 1'b1;
-            din_a.value    = dout_a.value;
-            din_a.capacity = curr.capacity;
-
             addr_b = child_idx_left;
             we_b = 1;
-            
             din_b.active   = 1'b0;
             din_b.value    = '0;
             din_b.capacity = dout_a.capacity + 1;
@@ -374,20 +303,13 @@ module bram_tree #(
             next.value    = curr.value;
             next.position = child_idx_left;
             next.capacity = dout_a.capacity + 1;
-            
-            next_out_reg = dout_a.value;
-            next_second_greatest = 'x;
-          end else if (dout_b.active && !dout_a.active) begin
-            addr_b = curr.position;
-            we_b = 1;
-            
-            din_b.active   = 1'b1;
-            din_b.value    = dout_b.value;
-            din_b.capacity = curr.capacity;
 
+            next_top_level.active   = 1'b1;
+            next_top_level.value    = dout_a.value;
+            next_top_level.capacity = curr.capacity;
+          end else if (dout_b.active && !dout_a.active) begin
             addr_a = child_idx_right;
             we_a = 1;
-            
             din_a.active   = 1'b0;
             din_a.value    = '0;
             din_a.capacity = dout_b.capacity + 1;
@@ -395,21 +317,14 @@ module bram_tree #(
             next.value    = curr.value;
             next.position = child_idx_right;
             next.capacity = dout_b.capacity + 1;
-            
-            next_out_reg = dout_b.value;
-            next_second_greatest = 'x;
+
+            next_top_level.active   = 1'b1;
+            next_top_level.value    = dout_b.value;
+            next_top_level.capacity = curr.capacity;
           end else if (dout_a.active && dout_b.active) begin
             if (dout_a.value >= dout_b.value) begin
-              addr_a = curr.position;
-              we_a = 1;
-              
-              din_a.active   = 1'b1;
-              din_a.value    = dout_a.value;
-              din_a.capacity = curr.capacity;
-
               addr_b = child_idx_left;
               we_b = 1;
-              
               din_b.active   = 1'b0;
               din_b.value    = '0;
               din_b.capacity = dout_a.capacity + 1;
@@ -417,20 +332,13 @@ module bram_tree #(
               next.value    = curr.value;
               next.position = child_idx_left;
               next.capacity = dout_a.capacity + 1;
-              
-              next_out_reg = dout_a.value;
-              next_second_greatest = dout_b.value;
-            end else begin
-              addr_b = curr.position;
-              we_b = 1;
-              
-              din_b.active   = 1'b1;
-              din_b.value    = dout_b.value;
-              din_b.capacity = curr.capacity;
 
+              next_top_level.active   = 1'b1;
+              next_top_level.value    = dout_a.value;
+              next_top_level.capacity = curr.capacity;
+            end else begin
               addr_a = child_idx_right;
               we_a = 1;
-              
               din_a.active   = 1'b0;
               din_a.value    = '0;
               din_a.capacity = dout_b.capacity + 1;
@@ -438,9 +346,10 @@ module bram_tree #(
               next.value    = curr.value;
               next.position = child_idx_right;
               next.capacity = dout_b.capacity + 1;
-              
-              next_out_reg = dout_b.value;
-              next_second_greatest = dout_a.value;
+
+              next_top_level.active   = 1'b1;
+              next_top_level.value    = dout_b.value;
+              next_top_level.capacity = curr.capacity;
             end
           end
           next_state = DEQUEUE_READ_CHILD;
@@ -449,7 +358,7 @@ module bram_tree #(
 
       DEQUEUE_READ_CHILD: begin
         //read child_idx_left and child_idx_right
-        if ((child_idx_left > QUEUE_SIZE) || (child_idx_right > QUEUE_SIZE)) begin
+        if (children_out_of_range) begin
           next_state = IDLE;
         end else begin
           addr_a = child_idx_left;
@@ -459,22 +368,20 @@ module bram_tree #(
       end
 
       DEQUEUE_COMPARE_CHILD: begin
-        //if both nodes are inactive or we are at the end, we go to idle next
-        if ((!dout_a.active && !dout_b.active) || (child_idx_left > QUEUE_SIZE) || (child_idx_right > QUEUE_SIZE)) begin
+        //if both nodes are inactive or we are past the end, we go to idle next
+        if (both_children_inactive || children_out_of_range) begin
           next_state = IDLE;
         end else begin
           // if only one is inactive we pull that value
           if (dout_a.active && !dout_b.active) begin
             addr_a = curr.position;
             we_a = 1;
-            
             din_a.active   = 1'b1;
             din_a.value    = dout_a.value;
             din_a.capacity = curr.capacity;
 
             addr_b = child_idx_left;
             we_b = 1;
-            
             din_b.active   = 1'b0;
             din_b.value    = '0;
             din_b.capacity = dout_a.capacity + 1;
@@ -485,14 +392,12 @@ module bram_tree #(
           end else if (dout_b.active && !dout_a.active) begin
             addr_b = curr.position;
             we_b = 1;
-            
             din_b.active   = 1'b1;
             din_b.value    = dout_b.value;
             din_b.capacity = curr.capacity;
 
             addr_a = child_idx_right;
             we_a = 1;
-            
             din_a.active   = 1'b0;
             din_a.value    = '0;
             din_a.capacity = dout_b.capacity + 1;
@@ -504,14 +409,12 @@ module bram_tree #(
             if (dout_a.value >= dout_b.value) begin
               addr_a = curr.position;
               we_a = 1;
-              
               din_a.active   = 1'b1;
               din_a.value    = dout_a.value;
               din_a.capacity = curr.capacity;
 
               addr_b = child_idx_left;
               we_b = 1;
-              
               din_b.active   = 1'b0;
               din_b.value    = '0;
               din_b.capacity = dout_a.capacity + 1;
@@ -522,14 +425,12 @@ module bram_tree #(
             end else begin
               addr_b = curr.position;
               we_b = 1;
-              
               din_b.active   = 1'b1;
               din_b.value    = dout_b.value;
               din_b.capacity = curr.capacity;
 
               addr_a = child_idx_right;
               we_a = 1;
-              
               din_a.active   = 1'b0;
               din_a.value    = '0;
               din_a.capacity = dout_b.capacity + 1;
@@ -543,44 +444,19 @@ module bram_tree #(
         end
       end
 
-      REPLACE_READ_ROOT: begin
-        //get the current capacity, and then read the children
-        addr_a = child_idx_left;
-        addr_b = child_idx_right;
-        
-        next.value    = curr.value;
-        next.position = 0;
-        next.capacity = dout_a.capacity;
-        
-        next_state = REPLACE_COMPARE_ROOT;
-      end
-
       REPLACE_COMPARE_ROOT: begin
         //if the current node is the only node or the greatest node, we just write into it and go back to idle
-        if ((!dout_a.active && !dout_b.active) || (child_idx_left > QUEUE_SIZE) || (child_idx_right > QUEUE_SIZE) || ((curr.value >= dout_a.value) && (curr.value >= dout_b.value))) begin
-          addr_a = curr.position;
-          we_a = 1;
-          
-          din_a.active   = 1'b1;
-          din_a.value    = curr.value;
-          din_a.capacity = curr.capacity;
-          
-          next_out_reg = curr.value;
+        if (both_children_inactive || children_out_of_range || ((curr.value >= dout_a.value) && (curr.value >= dout_b.value))) begin
+          next_top_level.active   = 1'b1;
+          next_top_level.value    = curr.value;
+          next_top_level.capacity = curr.capacity;
           next_state = IDLE;
         end else begin
           // otherwise swap with the higher priority node
           // swap with A
           if ((dout_a.active && !dout_b.active) || (dout_a.value >= dout_b.value)) begin
-            addr_a = curr.position;
-            we_a = 1;
-            
-            din_a.active   = 1'b1;
-            din_a.value    = dout_a.value;
-            din_a.capacity = curr.capacity;
-
             addr_b = child_idx_left;
             we_b = 1;
-            
             din_b.active   = 1'b1;
             din_b.value    = curr.value;
             din_b.capacity = dout_a.capacity;
@@ -588,19 +464,13 @@ module bram_tree #(
             next.value    = curr.value;
             next.position = child_idx_left;
             next.capacity = dout_a.capacity;
-            
-            next_out_reg = dout_a.value;
-          end else if ((dout_b.active && !dout_a.active) || (dout_b.value >= dout_a.value)) begin
-            addr_b = curr.position;
-            we_b = 1;
-            
-            din_b.active   = 1'b1;
-            din_b.value    = dout_b.value;
-            din_b.capacity = curr.capacity;
 
+            next_top_level.active   = 1'b1;
+            next_top_level.value    = dout_a.value;
+            next_top_level.capacity = curr.capacity;
+          end else if ((dout_b.active && !dout_a.active) || (dout_b.value >= dout_a.value)) begin
             addr_a = child_idx_right;
             we_a = 1;
-            
             din_a.active   = 1'b1;
             din_a.value    = curr.value;
             din_a.capacity = dout_b.capacity;
@@ -608,8 +478,10 @@ module bram_tree #(
             next.value    = curr.value;
             next.position = child_idx_right;
             next.capacity = dout_b.capacity;
-            
-            next_out_reg = dout_b.value;
+
+            next_top_level.active   = 1'b1;
+            next_top_level.value    = dout_b.value;
+            next_top_level.capacity = curr.capacity;
           end
           next_state = REPLACE_READ_CHILD;
         end
@@ -617,7 +489,7 @@ module bram_tree #(
 
       REPLACE_READ_CHILD: begin
         //read child_idx_left and child_idx_right
-        if ((child_idx_left > QUEUE_SIZE) || (child_idx_right > QUEUE_SIZE)) begin
+        if (children_out_of_range) begin
           next_state = IDLE;
         end else begin
           addr_a = child_idx_left;
@@ -625,16 +497,14 @@ module bram_tree #(
           next_state = REPLACE_COMPARE_CHILD;
         end
       end
-      
+
       REPLACE_COMPARE_CHILD: begin
-        if ((!dout_a.active && !dout_b.active) || (child_idx_left > QUEUE_SIZE) || (child_idx_right > QUEUE_SIZE) || ((curr.value >= dout_a.value) && (curr.value >= dout_b.value))) begin
+        if (both_children_inactive || children_out_of_range || ((curr.value >= dout_a.value) && (curr.value >= dout_b.value))) begin
           addr_a = curr.position;
           we_a = 1;
-          
           din_a.active   = 1'b1;
           din_a.value    = curr.value;
           din_a.capacity = curr.capacity;
-          
           next_state = IDLE;
         end else begin
           // otherwise swap with the higher priority node
@@ -642,14 +512,12 @@ module bram_tree #(
           if ((dout_a.active && !dout_b.active) || (dout_a.value >= dout_b.value)) begin
             addr_a = curr.position;
             we_a = 1;
-            
             din_a.active   = 1'b1;
             din_a.value    = dout_a.value;
             din_a.capacity = curr.capacity;
 
             addr_b = child_idx_left;
             we_b = 1;
-            
             din_b.active   = 1'b1;
             din_b.value    = curr.value;
             din_b.capacity = dout_a.capacity;
@@ -660,14 +528,12 @@ module bram_tree #(
           end else if ((dout_b.active && !dout_a.active) || (dout_b.value >= dout_a.value)) begin
             addr_b = curr.position;
             we_b = 1;
-            
             din_b.active   = 1'b1;
             din_b.value    = dout_b.value;
             din_b.capacity = curr.capacity;
 
             addr_a = child_idx_right;
             we_a = 1;
-            
             din_a.active   = 1'b1;
             din_a.value    = curr.value;
             din_a.capacity = dout_b.capacity;
@@ -682,8 +548,9 @@ module bram_tree #(
     endcase
   end
 
-  assign o_write_ready  = !(queue_size == QUEUE_SIZE);
-  assign o_read_ready = !(queue_size == 0);
-  assign o_data  = (queue_size == 0) ? 0 : out_reg;
-  assign ready   = (state == IDLE);
+  assign idle_and_no_new_request = (state == IDLE) && !(i_read || i_wrt);
+  assign o_write_ready = (queue_size != QUEUE_SIZE) && idle_and_no_new_request;
+  assign o_read_ready  = (queue_size != 0)           && idle_and_no_new_request;
+  assign o_data        = (queue_size == 0) ? 0 : top_level.value;
+  assign empty          = (queue_size == 0);
 endmodule

--- a/hwpq/bram_tree_pipelined/rtl/sim/pipelined_bram_tree_tb.sv
+++ b/hwpq/bram_tree_pipelined/rtl/sim/pipelined_bram_tree_tb.sv
@@ -50,6 +50,8 @@ module bram_tree_pipelined_tb;
   // Clock generation: 10ns period
   always #5 CLK <= ~CLK;
 
+  int error_count = 0;
+
   initial begin
     // Initialize signals
     CLK = 0;
@@ -81,10 +83,10 @@ module bram_tree_pipelined_tb;
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue[0])
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
         assert (o_data == '0)
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -109,7 +111,7 @@ module bram_tree_pipelined_tb;
       random_value = DataWidth'(($urandom & ((1 << DataWidth) - 1)) % 1025);
       replace(random_value);
       assert (o_data == ref_queue[0])
-      else $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+      else begin error_count++; $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
     end
 
     // Test Case 3: Stress Test
@@ -124,10 +126,10 @@ module bram_tree_pipelined_tb;
           if (!o_empty) begin
             assert (o_data == ref_queue[0])
             else
-              $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+              begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
           end else begin
             assert (o_data == '0)
-            else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+            else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
 
@@ -135,7 +137,7 @@ module bram_tree_pipelined_tb;
           replace(random_value);
           assert (o_data == ref_queue[0])
           else
-            $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+            begin error_count++; $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
         end
 
         default: begin
@@ -144,8 +146,13 @@ module bram_tree_pipelined_tb;
       endcase
     end
 
-    $display("\nTest completed! ");
-    $finish;
+    if (error_count == 0) begin
+      $display("\nTest completed!");
+      $finish;
+    end else begin
+      $display("\n%0d error(s) detected during simulation.", error_count);
+      $fatal(1, "Test FAILED with %0d error(s).", error_count);
+    end
   end
 
   // Task to read root node

--- a/hwpq/bram_tree_pipelined/rtl/sim/pipelined_bram_tree_tb.sv
+++ b/hwpq/bram_tree_pipelined/rtl/sim/pipelined_bram_tree_tb.sv
@@ -4,8 +4,8 @@ module bram_tree_pipelined_tb;
   localparam integer DataWidth = 16;
 
   // Clock and reset signals
-  logic                   CLK;
-  logic                   RSTn;
+  logic                   i_CLK;
+  logic                   i_RSTn;
 
   // Input signals
   logic                   i_wrt;
@@ -37,8 +37,8 @@ module bram_tree_pipelined_tb;
       .QUEUE_SIZE(QueueSize),
       .DATA_WIDTH(DataWidth)
   ) uut (
-      .CLK(CLK),
-      .RSTn(RSTn),
+      .i_CLK(i_CLK),
+      .i_RSTn(i_RSTn),
       .i_wrt(i_wrt),
       .i_read(i_read),
       .i_data(i_data),
@@ -48,22 +48,22 @@ module bram_tree_pipelined_tb;
   );
 
   // Clock generation: 10ns period
-  always #5 CLK <= ~CLK;
+  always #5 i_CLK <= ~i_CLK;
 
   int error_count = 0;
 
   initial begin
     // Initialize signals
-    CLK = 0;
-    RSTn = 0;
+    i_CLK = 0;
+    i_RSTn = 0;
     i_wrt = 0;
     i_read = 0;
     i_data = 0;
 
     // Reset the module
-    @(posedge CLK);
-    RSTn = 1;
-    repeat (2) @(posedge CLK);
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    repeat (2) @(posedge i_CLK);
 
     // Initialize the reference queue, sort the reference queue, and write to the queue
     for (i = 0; i < QueueSize; i++) begin
@@ -74,7 +74,7 @@ module bram_tree_pipelined_tb;
     end
     rsort();
 
-    repeat (16) @(posedge CLK);
+    repeat (16) @(posedge i_CLK);
 
     // Test Case 1: Dequeue nodes
     // Dequeue nodes for QUEUE_SIZE times
@@ -91,9 +91,9 @@ module bram_tree_pipelined_tb;
     end
 
     /*// Reset the module
-    @(posedge CLK);
-    RSTn = 1;
-    repeat (2) @(posedge CLK);
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    repeat (2) @(posedge i_CLK);
 
     for (i = 0; i < QueueSize; i++) begin
       random_value = DataWidth'(($urandom & ((1 << DataWidth) - 1)) % 1025);
@@ -102,7 +102,7 @@ module bram_tree_pipelined_tb;
     end
     ref_queue.rsort();*/
     
-    repeat (16) @(posedge CLK);
+    repeat (16) @(posedge i_CLK);
 
     // Test Case 2: Replace nodes
     // Replace root node for QUEUE_SIZE times
@@ -169,10 +169,10 @@ module bram_tree_pipelined_tb;
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (24) @(posedge CLK);
+      repeat (24) @(posedge i_CLK);
     end
   endtask
 
@@ -190,10 +190,10 @@ module bram_tree_pipelined_tb;
         ref_queue[0] = value;
         rsort();
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (24) @(posedge CLK);
+      repeat (24) @(posedge i_CLK);
     end
   endtask
 
@@ -202,10 +202,10 @@ module bram_tree_pipelined_tb;
       i_wrt  = 1;
       i_read = 1;
       i_data = value;
-      repeat (1) @(posedge CLK);
+      repeat (1) @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (24) @(posedge CLK);
+      repeat (24) @(posedge i_CLK);
     end
   endtask
 

--- a/hwpq/bram_tree_pipelined/rtl/sim/pipelined_bram_tree_tb.sv
+++ b/hwpq/bram_tree_pipelined/rtl/sim/pipelined_bram_tree_tb.sv
@@ -13,8 +13,8 @@ module bram_tree_pipelined_tb;
   logic   [DataWidth-1:0] i_data;
 
   // Output signals
-  logic                   o_full;
-  logic                   o_empty;
+  logic                   o_write_ready;
+  logic                   o_read_ready;
   logic   [DataWidth-1:0] o_data;
 
   // Reference array for verification
@@ -42,8 +42,8 @@ module bram_tree_pipelined_tb;
       .i_wrt(i_wrt),
       .i_read(i_read),
       .i_data(i_data),
-      .o_full(o_full),
-      .o_empty(o_empty),
+      .o_write_ready(o_write_ready),
+      .o_read_ready(o_read_ready),
       .o_data(o_data)
   );
 
@@ -81,7 +81,7 @@ module bram_tree_pipelined_tb;
     $display("\nTest Case 1: Dequeue Test");
     for (i = 0; i < QueueSize/2; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue[0])
         else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
@@ -123,7 +123,7 @@ module bram_tree_pipelined_tb;
       case (random_operation)
         DEQUEUE: begin
           dequeue();
-          if (!o_empty) begin
+          if (o_read_ready) begin
             assert (o_data == ref_queue[0])
             else
               begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
@@ -158,7 +158,7 @@ module bram_tree_pipelined_tb;
   // Task to read root node
   task automatic dequeue();
     begin
-      if (!o_empty) begin
+      if (o_read_ready) begin
         i_wrt  = 0;
         i_read = 1;
         for (int i = 0; i < ref_queue_size - 1; i++) begin
@@ -182,7 +182,7 @@ module bram_tree_pipelined_tb;
       i_wrt  = 1;
       i_read = 1;
       i_data = value;
-      if (o_empty) begin
+      if (!o_read_ready) begin
         ref_queue[ref_queue_size] = value;
         ref_queue_size++;
         rsort();

--- a/hwpq/bram_tree_pipelined/rtl/sim/pipelined_bram_tree_tb.sv
+++ b/hwpq/bram_tree_pipelined/rtl/sim/pipelined_bram_tree_tb.sv
@@ -50,6 +50,23 @@ module bram_tree_pipelined_tb;
   // Clock generation: 10ns period
   always #5 i_CLK <= ~i_CLK;
 
+  logic settled;
+  assign settled = o_write_ready;
+  
+  localparam int SETTLE_TIMEOUT = 10000;
+  task automatic poll_settled();
+    int guard;
+    guard = 0;
+    while (!settled) begin
+      @(negedge i_CLK);
+      guard++;
+      if (guard > SETTLE_TIMEOUT) begin
+        $fatal(1, "poll_settled: DUT never settled after %0d cycles (o_write_ready=%0b o_read_ready=%0b)",
+               SETTLE_TIMEOUT, o_write_ready, o_read_ready);
+      end
+    end
+  endtask
+
   int error_count = 0;
 
   initial begin
@@ -64,6 +81,7 @@ module bram_tree_pipelined_tb;
     @(posedge i_CLK);
     i_RSTn = 1;
     repeat (2) @(posedge i_CLK);
+    @(negedge i_CLK);
 
     // Initialize the reference queue, sort the reference queue, and write to the queue
     for (i = 0; i < QueueSize; i++) begin
@@ -74,7 +92,7 @@ module bram_tree_pipelined_tb;
     end
     rsort();
 
-    repeat (16) @(posedge i_CLK);
+    poll_settled();
 
     // Test Case 1: Dequeue nodes
     // Dequeue nodes for QUEUE_SIZE times
@@ -94,6 +112,7 @@ module bram_tree_pipelined_tb;
     @(posedge i_CLK);
     i_RSTn = 1;
     repeat (2) @(posedge i_CLK);
+    @(negedge i_CLK);
 
     for (i = 0; i < QueueSize; i++) begin
       random_value = DataWidth'(($urandom & ((1 << DataWidth) - 1)) % 1025);
@@ -102,7 +121,7 @@ module bram_tree_pipelined_tb;
     end
     ref_queue.rsort();*/
     
-    repeat (16) @(posedge i_CLK);
+    poll_settled();
 
     // Test Case 2: Replace nodes
     // Replace root node for QUEUE_SIZE times
@@ -158,6 +177,7 @@ module bram_tree_pipelined_tb;
   // Task to read root node
   task automatic dequeue();
     begin
+      poll_settled();
       if (o_read_ready) begin
         i_wrt  = 0;
         i_read = 1;
@@ -170,15 +190,17 @@ module bram_tree_pipelined_tb;
         $display("Dequeue: Queue empty, skipping dequeue");
       end
       @(posedge i_CLK);
+      @(negedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (24) @(posedge i_CLK);
+      poll_settled();
     end
   endtask
 
   // Task to replace root node
   task automatic replace(input logic [DataWidth-1:0] value);
     begin
+      poll_settled();
       i_wrt  = 1;
       i_read = 1;
       i_data = value;
@@ -191,21 +213,24 @@ module bram_tree_pipelined_tb;
         rsort();
       end
       @(posedge i_CLK);
+      @(negedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (24) @(posedge i_CLK);
+      poll_settled();
     end
   endtask
 
   task automatic replace_init(input logic [DataWidth-1:0] value);
     begin
+      poll_settled();
       i_wrt  = 1;
       i_read = 1;
       i_data = value;
-      repeat (1) @(posedge i_CLK);
+      @(posedge i_CLK);
+      @(negedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (24) @(posedge i_CLK);
+      poll_settled();
     end
   endtask
 

--- a/hwpq/bram_tree_pipelined/rtl/src/bram_tree_pipelined.sv
+++ b/hwpq/bram_tree_pipelined/rtl/src/bram_tree_pipelined.sv
@@ -8,8 +8,8 @@
                for improved scalability over the non-pipelined BRAM tree.
   Parameters: QUEUE_SIZE - Maximum number of elements in the priority queue
               DATA_WIDTH - Bit width of data elements
-  Inputs: CLK - System clock
-          RSTn - Active-low reset signal
+  Inputs: i_CLK - System clock
+          i_RSTn - Active-low reset signal
           i_wrt - Write/insert command (enqueue operation)
           i_read - Read/pop command (dequeue operation)
           i_data - Input data to be inserted (or used for replace)
@@ -22,8 +22,8 @@ module bram_tree_pipelined #(
     parameter integer QUEUE_SIZE = 7,
     parameter integer DATA_WIDTH = 16
 ) (
-    input  logic                  CLK,
-    input  logic                  RSTn,
+    input  logic                  i_CLK,
+    input  logic                  i_RSTn,
     // Inputs
     input  logic                  i_wrt,    // Write/insert command
     input  logic                  i_read,   // Read/pop command
@@ -117,13 +117,13 @@ module bram_tree_pipelined #(
           .WIDTH(DATA_WIDTH),
           .DEPTH(NODES_NEEDED)
       ) bram_inst (
-          .clka (CLK),
+          .clka (i_CLK),
           .ena  (1'b1),
           .wea  (we_a[i]),
           .addra(addr_a[i]),
           .dia  (din_a[i]),
           .doa  (dout_a[i]),
-          .clkb (CLK),
+          .clkb (i_CLK),
           .enb  (1'b1),
           .web  (we_b[i]),
           .addrb(addr_b[i]),
@@ -150,8 +150,8 @@ module bram_tree_pipelined #(
   //-------------------------------------------------------------------------
   // FSM
   //-------------------------------------------------------------------------
-  always_ff @(posedge CLK or negedge RSTn) begin : fsm_seq
-    if (!RSTn) begin
+  always_ff @(posedge i_CLK or negedge i_RSTn) begin : fsm_seq
+    if (!i_RSTn) begin
       state <= IDLE;
     end else begin
       state <= next_state;
@@ -223,8 +223,8 @@ module bram_tree_pipelined #(
   //-------------------------------------------------------------------------
   // BRAM read&write, heap management
   //-------------------------------------------------------------------------
-  always_ff @(posedge CLK or negedge RSTn) begin : bram_seq
-    if (!RSTn) begin
+  always_ff @(posedge i_CLK or negedge i_RSTn) begin : bram_seq
+    if (!i_RSTn) begin
       parent_lvl <= '0;
       parent_idx <= '0;
       level_0 <= '1;
@@ -397,8 +397,8 @@ module bram_tree_pipelined #(
   //-------------------------------------------------------------------------
   // Queue size counter
   //-------------------------------------------------------------------------
-  always_ff @(posedge CLK or negedge RSTn) begin : queue_size_seq
-    if (!RSTn) begin
+  always_ff @(posedge i_CLK or negedge i_RSTn) begin : queue_size_seq
+    if (!i_RSTn) begin
       queue_size <= 0;
     end else begin
       queue_size <= next_queue_size;

--- a/hwpq/bram_tree_pipelined/rtl/src/bram_tree_pipelined.sv
+++ b/hwpq/bram_tree_pipelined/rtl/src/bram_tree_pipelined.sv
@@ -90,6 +90,11 @@ module bram_tree_pipelined #(
   // Size counter to keep track of the number of nodes in the queue
   logic [31:0] queue_size, next_queue_size;
 
+  logic sift_done, next_sift_done;  // whole walk finished - may accept a command
+  logic root_done, next_root_done;  // root written back - o_data is trustworthy
+  logic cmd_dequeue, cmd_replace;
+  logic [DATA_WIDTH-1:0] cmd_data;   // command payload latched at accept
+
   // integers for iteration
   integer lvl_seq, itr_seq, lvl_comb, itr_comb;
 
@@ -163,36 +168,36 @@ module bram_tree_pipelined #(
     case (state)
       IDLE: begin
         next_state = READ_MEM;
-        if (!i_wrt && i_read) begin  // dequeue
+        if (cmd_dequeue) begin  // dequeue
           next_state = DEQUEUE;
-        end else if (i_wrt && i_read) begin  // replace
+        end else if (cmd_replace) begin  // replace
           next_state = REPLACE;
         end
       end
 
       READ_MEM: begin
         next_state = WAIT;
-        if (!i_wrt && i_read) begin  // dequeue
+        if (cmd_dequeue) begin  // dequeue
           next_state = DEQUEUE;
-        end else if (i_wrt && i_read) begin  // replace
+        end else if (cmd_replace) begin  // replace
           next_state = REPLACE;
         end
       end
 
       COMPARE_SWAP: begin
         next_state = WRITE_MEM;
-        if (!i_wrt && i_read) begin  // dequeue
+        if (cmd_dequeue) begin  // dequeue
           next_state = DEQUEUE;
-        end else if (i_wrt && i_read) begin  // replace
+        end else if (cmd_replace) begin  // replace
           next_state = REPLACE;
         end
       end
 
       WRITE_MEM: begin
         next_state = READ_MEM;
-        if (!i_wrt && i_read) begin  // dequeue
+        if (cmd_dequeue) begin  // dequeue
           next_state = DEQUEUE;
-        end else if (i_wrt && i_read) begin  // replace
+        end else if (cmd_replace) begin  // replace
           next_state = REPLACE;
         end
       end
@@ -207,9 +212,9 @@ module bram_tree_pipelined #(
 
       WAIT: begin
         next_state = COMPARE_SWAP;
-        if (!i_wrt && i_read) begin  // dequeue
+        if (cmd_dequeue) begin  // dequeue
           next_state = DEQUEUE;
-        end else if (i_wrt && i_read) begin  // replace
+        end else if (cmd_replace) begin  // replace
           next_state = REPLACE;
         end
       end
@@ -381,7 +386,7 @@ module bram_tree_pipelined #(
       end
 
       REPLACE: begin
-        next_level_0 = i_data;
+        next_level_0 = cmd_data;  // latched at accept; i_data may be gone by now
         next_parent_lvl = 'd0;
         next_parent_idx = 'd0;
       end
@@ -405,14 +410,15 @@ module bram_tree_pipelined #(
     end
   end
 
+  // There is deliberately no enqueue branch: this module has no enqueue path in the FSM at all.
+  // The counter used to increment on (i_wrt && !i_read) so a master driving i_wrt alone bumped queue_size with no data ever
+  // inserted, over-reporting occupancy
   always_comb begin : queue_size_comb
     next_queue_size = queue_size;
-    if (i_wrt && !i_read) begin  // enqueue
-      next_queue_size = queue_size + 1;
-    end else if (!i_wrt && i_read) begin  // dequeue
-      next_queue_size = queue_size - 1;
-    end else if (i_wrt && i_read) begin  // replace
-      if (o_data == '1) begin //special case for following a reset, we need to replace all the values in 
+    if (cmd_dequeue) begin
+      next_queue_size = queue_size - 1; // cmd_dequeue is gated on !empty so this cannot underflow
+    end else if (cmd_replace) begin
+      if (o_data == '1) begin //special case for following a reset, we need to replace all the values in
         next_queue_size = queue_size + 1;
       end else if (queue_size == 0 && i_data != 0) begin  // this would be a special case for replace, function as enqueue
         next_queue_size = queue_size + 1;
@@ -422,11 +428,59 @@ module bram_tree_pipelined #(
     end
   end
 
+  // Sift-down completion detector
+  
+  //   root_done -- the root compare-swap has been written back, so level_0 now
+  //                holds the true maximum.  o_data is trustworthy from here,
+  //                even though the walk may still be sifting deeper down.
+
+  //   sift_done -- the whole walk terminated.  Only now may a new command be
+  //                accepted; one arriving earlier abandons the walk part-way
+  //                down and leaves the heap broken.
+  
+  // sift_done implies root_done so gating every command on sift_done alone is sufficient and
+  // root_done is free to report the earlier instant to a reader.
+  always_ff @(posedge i_CLK or negedge i_RSTn) begin : done_seq
+    if (!i_RSTn) begin
+      sift_done <= 1'b1;
+      root_done <= 1'b1;
+    end else begin
+      sift_done <= next_sift_done;
+      root_done <= next_root_done;
+    end
+  end
+
+  always_comb begin : done_comb
+    next_sift_done = sift_done;
+    next_root_done = root_done;
+    if (cmd_dequeue || cmd_replace) begin
+      next_sift_done = 1'b0;
+      next_root_done = 1'b0;
+    end else if (state == WRITE_MEM) begin
+      if (parent_lvl == '0)      next_root_done = 1'b1;  // root written back
+      if (next_parent_lvl == '0) next_sift_done = 1'b1;  // walk terminated
+    end
+  end
+
+  assign cmd_dequeue = !i_wrt && i_read && sift_done && (queue_size != 0);
+  assign cmd_replace = i_wrt && i_read && sift_done;
+
+  // The replace state does not execute until the cycle after the command is accepted, so sampling i_data there would read
+  // whatever the master happens to be driving one cycle later.  Every other queue in this repo captures i_data in the same cycle, 
+  // so latching the value here makes this module honor the same contract, and needs no special behavious from master
+  always_ff @(posedge i_CLK or negedge i_RSTn) begin : cmd_data_seq
+    if (!i_RSTn) begin
+      cmd_data <= '0;
+    end else if (cmd_replace) begin
+      cmd_data <= i_data;
+    end
+  end
+
   //-------------------------------------------------------------------------
   // Assignments for status and output.
   //-------------------------------------------------------------------------
-  assign o_write_ready  = !(queue_size == QUEUE_SIZE);
-  assign o_read_ready = !(queue_size == 0);
+  assign o_write_ready = sift_done;
+  assign o_read_ready  = !(queue_size == 0) && root_done;
   assign o_data  = level_0;
 
 endmodule

--- a/hwpq/bram_tree_pipelined/rtl/src/bram_tree_pipelined.sv
+++ b/hwpq/bram_tree_pipelined/rtl/src/bram_tree_pipelined.sv
@@ -1,3 +1,24 @@
+/*******************************************************************************
+  Module Name: bram_tree_pipelined
+  Date: 2026/06/23
+  Description: A pipelined priority queue implementation using a binary max-heap
+               structure stored in block RAM, with the top few levels
+               kept in registers. Supports enqueue, dequeue, and replace
+               operations, trading throughput (one replace every four cycles)
+               for improved scalability over the non-pipelined BRAM tree.
+  Parameters: QUEUE_SIZE - Maximum number of elements in the priority queue
+              DATA_WIDTH - Bit width of data elements
+  Inputs: CLK - System clock
+          RSTn - Active-low reset signal
+          i_wrt - Write/insert command (enqueue operation)
+          i_read - Read/pop command (dequeue operation)
+          i_data - Input data to be inserted (or used for replace)
+  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
+           o_empty - High when the queue is empty
+           o_valid - High when o_data holds a valid output
+           o_data - Output data from the highest priority element
+*******************************************************************************/
+
 module bram_tree_pipelined #(
     parameter integer QUEUE_SIZE = 7,
     parameter integer DATA_WIDTH = 16

--- a/hwpq/bram_tree_pipelined/rtl/src/bram_tree_pipelined.sv
+++ b/hwpq/bram_tree_pipelined/rtl/src/bram_tree_pipelined.sv
@@ -13,9 +13,9 @@
           i_wrt - Write/insert command (enqueue operation)
           i_read - Read/pop command (dequeue operation)
           i_data - Input data to be inserted (or used for replace)
-  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
-           o_empty - High when the queue is empty
-           o_data - Output data from the highest priority element
+Outputs:    o_write_ready - High when the queue has room to accept a write
+            o_read_ready - High when the queue holds data available to read
+            o_data - Output data from the highest priority element
 *******************************************************************************/
 
 module bram_tree_pipelined #(
@@ -29,8 +29,8 @@ module bram_tree_pipelined #(
     input  logic                  i_read,   // Read/pop command
     input  logic [DATA_WIDTH-1:0] i_data,   // Data to be inserted (or used for replace)
     // Outputs
-    output logic                  o_full,   // High if the heap is full
-    output logic                  o_empty,  // High if the heap is empty
+    output logic                  o_write_ready,   // High if the queue can accept a write
+    output logic                  o_read_ready,  // High if the queue has data to read
     output logic [DATA_WIDTH-1:0] o_data    // Output data (popped value)
 );
 
@@ -425,8 +425,8 @@ module bram_tree_pipelined #(
   //-------------------------------------------------------------------------
   // Assignments for status and output.
   //-------------------------------------------------------------------------
-  assign o_full  = (queue_size == QUEUE_SIZE);
-  assign o_empty = (queue_size == 0);
+  assign o_write_ready  = !(queue_size == QUEUE_SIZE);
+  assign o_read_ready = !(queue_size == 0);
   assign o_data  = level_0;
 
 endmodule

--- a/hwpq/bram_tree_pipelined/rtl/src/bram_tree_pipelined.sv
+++ b/hwpq/bram_tree_pipelined/rtl/src/bram_tree_pipelined.sv
@@ -15,7 +15,6 @@
           i_data - Input data to be inserted (or used for replace)
   Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
            o_empty - High when the queue is empty
-           o_valid - High when o_data holds a valid output
            o_data - Output data from the highest priority element
 *******************************************************************************/
 

--- a/hwpq/hybrid_tree/rtl/sim/hybrid_tree_tb.sv
+++ b/hwpq/hybrid_tree/rtl/sim/hybrid_tree_tb.sv
@@ -4,8 +4,8 @@ module hybrid_tree_tb;
   localparam integer DataWidth = 16;
 
   // Clock and reset signals
-  logic                   CLK;
-  logic                   RSTn;
+  logic                   i_CLK;
+  logic                   i_RSTn;
 
   // Input signals
   logic                   i_wrt;
@@ -35,8 +35,8 @@ module hybrid_tree_tb;
       .QUEUE_SIZE(QueueSize),
       .DATA_WIDTH(DataWidth)
   ) uut (
-      .CLK(CLK),
-      .RSTn(RSTn),
+      .i_CLK(i_CLK),
+      .i_RSTn(i_RSTn),
       .i_wrt(i_wrt),
       .i_read(i_read),
       .i_data(i_data),
@@ -46,20 +46,20 @@ module hybrid_tree_tb;
   );
 
   // Clock generation: 10ns period
-  always #5 CLK <= ~CLK;
+  always #5 i_CLK <= ~i_CLK;
 
   initial begin
     // Initialize signals
-    CLK = 0;
-    RSTn = 0;
+    i_CLK = 0;
+    i_RSTn = 0;
     i_wrt = 0;
     i_read = 0;
     i_data = 0;
 
     // Reset the module
-    @(posedge CLK);
-    RSTn = 1;
-    @(posedge CLK);
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    @(posedge i_CLK);
 
     // Initialize the reference queue, sort the reference queue, and write to the queue
     for (int i = 0; i < QueueSize; i++) begin
@@ -102,7 +102,7 @@ module hybrid_tree_tb;
 
     uut.next_size = 4;
 
-    repeat (8) @(posedge CLK);
+    repeat (8) @(posedge i_CLK);
 
     // Test Case: Replace nodes
     $display("\nReplace Test");
@@ -128,10 +128,10 @@ module hybrid_tree_tb;
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (24) @(posedge CLK);
+      repeat (24) @(posedge i_CLK);
     end
   endtask
 
@@ -144,10 +144,10 @@ module hybrid_tree_tb;
       ref_queue.pop_front();
       ref_queue.push_back(value);
       ref_queue.rsort();
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (4) @(posedge CLK);
+      repeat (4) @(posedge i_CLK);
     end
   endtask
 

--- a/hwpq/hybrid_tree/rtl/sim/hybrid_tree_tb.sv
+++ b/hwpq/hybrid_tree/rtl/sim/hybrid_tree_tb.sv
@@ -13,8 +13,8 @@ module hybrid_tree_tb;
   logic   [DataWidth-1:0] i_data;
 
   // Output signals
-  logic                   o_full;
-  logic                   o_empty;
+  logic                   o_write_ready;
+  logic                   o_read_ready;
   logic   [DataWidth-1:0] o_data;
 
   // Reference array for verification
@@ -40,8 +40,8 @@ module hybrid_tree_tb;
       .i_wrt(i_wrt),
       .i_read(i_read),
       .i_data(i_data),
-      .o_full(o_full),
-      .o_empty(o_empty),
+      .o_write_ready(o_write_ready),
+      .o_read_ready(o_read_ready),
       .o_data(o_data)
   );
 
@@ -120,7 +120,7 @@ module hybrid_tree_tb;
   // Task to read root node
   task automatic dequeue();
     begin
-      if (!o_empty) begin
+      if (o_read_ready) begin
         i_wrt  = 0;
         i_read = 1;
         ref_queue.pop_front();

--- a/hwpq/hybrid_tree/rtl/sim/pipelined_bram_tree_tb.sv
+++ b/hwpq/hybrid_tree/rtl/sim/pipelined_bram_tree_tb.sv
@@ -4,8 +4,8 @@ module pipelined_bram_tree_tb;
   localparam integer DataWidth = 16;
 
   // Clock and reset signals
-  logic                   CLK;
-  logic                   RSTn;
+  logic                   i_CLK;
+  logic                   i_RSTn;
 
   // Input signals
   logic                   i_wrt;
@@ -36,8 +36,8 @@ module pipelined_bram_tree_tb;
       .QUEUE_SIZE(QueueSize),
       .DATA_WIDTH(DataWidth)
   ) uut (
-      .CLK(CLK),
-      .RSTn(RSTn),
+      .i_CLK(i_CLK),
+      .i_RSTn(i_RSTn),
       .i_wrt(i_wrt),
       .i_read(i_read),
       .i_data(i_data),
@@ -48,20 +48,20 @@ module pipelined_bram_tree_tb;
   );
 
   // Clock generation: 10ns period
-  always #5 CLK <= ~CLK;
+  always #5 i_CLK <= ~i_CLK;
 
   initial begin
     // Initialize signals
-    CLK = 0;
-    RSTn = 0;
+    i_CLK = 0;
+    i_RSTn = 0;
     i_wrt = 0;
     i_read = 0;
     i_data = 0;
 
     // Reset the module
-    @(posedge CLK);
-    RSTn = 1;
-    @(posedge CLK);
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    @(posedge i_CLK);
 
     // Initialize the reference queue, sort the reference queue, and write to the queue
     for (int i = 0; i < QueueSize; i++) begin
@@ -87,7 +87,7 @@ module pipelined_bram_tree_tb;
     uut.next_queue_size = QueueSize;
     uut.next_state = 0;
 
-    repeat (16) @(posedge CLK);
+    repeat (16) @(posedge i_CLK);
 
     // Test Case 1: Dequeue nodes
     // Dequeue nodes for QUEUE_SIZE times
@@ -126,7 +126,7 @@ module pipelined_bram_tree_tb;
     uut.next_queue_size = QueueSize;
     uut.next_state = 0;
 
-    repeat (16) @(posedge CLK);
+    repeat (16) @(posedge i_CLK);
 
     // Test Case 2: Replace nodes
     // Replace root node for QUEUE_SIZE times
@@ -185,10 +185,10 @@ module pipelined_bram_tree_tb;
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (24) @(posedge CLK);
+      repeat (24) @(posedge i_CLK);
     end
   endtask
 
@@ -201,10 +201,10 @@ module pipelined_bram_tree_tb;
       ref_queue.pop_front();
       ref_queue.push_back(value);
       ref_queue.rsort();
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (24) @(posedge CLK);
+      repeat (24) @(posedge i_CLK);
     end
   endtask
 

--- a/hwpq/hybrid_tree/rtl/sim/pipelined_bram_tree_tb.sv
+++ b/hwpq/hybrid_tree/rtl/sim/pipelined_bram_tree_tb.sv
@@ -13,8 +13,8 @@ module pipelined_bram_tree_tb;
   logic   [DataWidth-1:0] i_data;
 
   // Output signals
-  logic                   o_full;
-  logic                   o_empty;
+  logic                   o_write_ready;
+  logic                   o_read_ready;
   logic                   o_valid;
   logic   [DataWidth-1:0] o_data;
 
@@ -41,8 +41,8 @@ module pipelined_bram_tree_tb;
       .i_wrt(i_wrt),
       .i_read(i_read),
       .i_data(i_data),
-      .o_full(o_full),
-      .o_empty(o_empty),
+      .o_write_ready(o_write_ready),
+      .o_read_ready(o_read_ready),
       .o_valid(o_valid),
       .o_data(o_data)
   );
@@ -94,7 +94,7 @@ module pipelined_bram_tree_tb;
     $display("\nTest Case 1: Dequeue Test");
     for (int i = 0; i < QueueSize; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue[0])
         else $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
       end else begin
@@ -147,7 +147,7 @@ module pipelined_bram_tree_tb;
       case (random_operation)
         DEQUEUE: begin
           dequeue();
-          if (!o_empty) begin
+          if (o_read_ready) begin
             assert (o_data == ref_queue[0])
             else
               $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
@@ -177,7 +177,7 @@ module pipelined_bram_tree_tb;
   // Task to read root node
   task automatic dequeue();
     begin
-      if (!o_empty) begin
+      if (o_read_ready) begin
         i_wrt  = 0;
         i_read = 1;
         ref_queue.pop_front();

--- a/hwpq/hybrid_tree/rtl/src/hybrid_tree.sv
+++ b/hwpq/hybrid_tree/rtl/src/hybrid_tree.sv
@@ -1,3 +1,24 @@
+/*******************************************************************************
+  Module Name: hybrid_tree
+  Date: 2025/03/21
+  Description: A hybrid priority queue (Max H-PQ) that combines a register
+               array holding the root nodes of multiple BRAM-based trees. New
+               items replace the leftmost register entry and propagate down
+               the corresponding BRAM tree, while the register array is kept
+               sorted so each entry is >= its right neighbor. Supports
+               enqueue, dequeue, and replace operations.
+  Parameters: QUEUE_SIZE - Maximum number of elements in the priority queue
+              DATA_WIDTH - Bit width of data elements
+  Inputs: CLK - System clock
+          RSTn - Active-low reset signal
+          i_wrt - Write/insert command (enqueue operation)
+          i_read - Read/pop command (dequeue operation)
+          i_data - Input data to be inserted (or used for replace)
+  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
+           o_empty - High when the queue is empty
+           o_data - Output data from the highest priority element
+*******************************************************************************/
+
 module hybrid_tree #(
     parameter integer QUEUE_SIZE = 4,
     parameter integer DATA_WIDTH = 16

--- a/hwpq/hybrid_tree/rtl/src/hybrid_tree.sv
+++ b/hwpq/hybrid_tree/rtl/src/hybrid_tree.sv
@@ -9,8 +9,8 @@
                enqueue, dequeue, and replace operations.
   Parameters: QUEUE_SIZE - Maximum number of elements in the priority queue
               DATA_WIDTH - Bit width of data elements
-  Inputs: CLK - System clock
-          RSTn - Active-low reset signal
+  Inputs: i_CLK - System clock
+          i_RSTn - Active-low reset signal
           i_wrt - Write/insert command (enqueue operation)
           i_read - Read/pop command (dequeue operation)
           i_data - Input data to be inserted (or used for replace)
@@ -23,8 +23,8 @@ module hybrid_tree #(
     parameter integer QUEUE_SIZE = 4,
     parameter integer DATA_WIDTH = 16
 ) (
-    input  logic                  CLK,
-    input  logic                  RSTn,
+    input  logic                  i_CLK,
+    input  logic                  i_RSTn,
     // Inputs
     input  logic                  i_wrt,    // Write/insert command
     input  logic                  i_read,   // Read/pop command
@@ -93,8 +93,8 @@ module hybrid_tree #(
   logic [$clog2(QUEUE_SIZE)-1:0] next_size;
   logic empty, full;
 
-  always_ff @(posedge CLK or negedge RSTn) begin : queue_size_seq
-    if (!RSTn) begin
+  always_ff @(posedge i_CLK or negedge i_RSTn) begin : queue_size_seq
+    if (!i_RSTn) begin
       size <= 0;
     end else begin
       size <= next_size;
@@ -167,8 +167,8 @@ module hybrid_tree #(
           .DATA_WIDTH(DATA_WIDTH),
           .QUEUE_SIZE(BRAM_SIZE)
       ) bram_tree_inst (
-          .CLK(CLK),
-          .RSTn(RSTn),
+          .i_CLK(i_CLK),
+          .i_RSTn(i_RSTn),
           .i_wrt(bram_i_wrt[bram_tree_gen]),
           .i_read(bram_i_read[bram_tree_gen]),
           .i_data(bram_i_data[bram_tree_gen]),
@@ -183,8 +183,8 @@ module hybrid_tree #(
   //-------------------------------------------------------------------------
   // Regsiter Array Mamagement
   //-------------------------------------------------------------------------
-  always_ff @(posedge CLK or negedge RSTn) begin : array_seq
-    if (!RSTn) begin
+  always_ff @(posedge i_CLK or negedge i_RSTn) begin : array_seq
+    if (!i_RSTn) begin
       for (int i = 0; i < ARRAY_SIZE; i++) begin
         level_0_data[i]   <= '{default: 0};
         level_0_target[i] <= '{default: 0};

--- a/hwpq/hybrid_tree/rtl/src/hybrid_tree.sv
+++ b/hwpq/hybrid_tree/rtl/src/hybrid_tree.sv
@@ -14,8 +14,8 @@
           i_wrt - Write/insert command (enqueue operation)
           i_read - Read/pop command (dequeue operation)
           i_data - Input data to be inserted (or used for replace)
-  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
-           o_empty - High when the queue is empty
+  Outputs: o_write_ready - High when the queue has room to accept a write
+           o_read_ready - High when the queue holds data available to read
            o_data - Output data from the highest priority element
 *******************************************************************************/
 
@@ -30,8 +30,8 @@ module hybrid_tree #(
     input  logic                  i_read,   // Read/pop command
     input  logic [DATA_WIDTH-1:0] i_data,   // Data to be inserted (or used for replace)
     // Outputs
-    output logic                  o_full,   // High if the heap is full
-    output logic                  o_empty,  // High if the heap is empty
+    output logic                  o_write_ready,   // High if the queue can accept a write
+    output logic                  o_read_ready,  // High if the queue has data to read
     output logic [DATA_WIDTH-1:0] o_data    // Output data (popped value)
 );
 
@@ -120,8 +120,8 @@ module hybrid_tree #(
   logic bram_i_read[ARRAY_SIZE-1:0];
   logic [DATA_WIDTH-1:0] bram_i_data[ARRAY_SIZE-1:0];
   logic [DATA_WIDTH-1:0] next_bram_i_data[ARRAY_SIZE-1:0];
-  logic bram_o_full[ARRAY_SIZE-1:0];
-  logic bram_o_empty[ARRAY_SIZE-1:0];
+  logic bram_o_write_ready[ARRAY_SIZE-1:0];
+  logic bram_o_read_ready[ARRAY_SIZE-1:0];
   logic bram_o_valid[ARRAY_SIZE-1:0];
   logic [DATA_WIDTH-1:0] bram_o_data[ARRAY_SIZE-1:0];
   logic bram_enqueue[ARRAY_SIZE-1:0];
@@ -172,8 +172,8 @@ module hybrid_tree #(
           .i_wrt(bram_i_wrt[bram_tree_gen]),
           .i_read(bram_i_read[bram_tree_gen]),
           .i_data(bram_i_data[bram_tree_gen]),
-          .o_full(bram_o_full[bram_tree_gen]),
-          .o_empty(bram_o_empty[bram_tree_gen]),
+          .o_write_ready(bram_o_write_ready[bram_tree_gen]),
+          .o_read_ready(bram_o_read_ready[bram_tree_gen]),
           .o_valid(bram_o_valid[bram_tree_gen]),
           .o_data(bram_o_data[bram_tree_gen])
       );
@@ -295,19 +295,19 @@ module hybrid_tree #(
   always_comb begin : empty_check
     empty = (size == 0);
     for (int i = 0; i < ARRAY_SIZE; i++) begin
-      empty = empty & bram_o_empty[i];  // AND operation to ensure all are empty
+      empty = empty & !bram_o_read_ready[i];  // AND operation to ensure all are empty
     end
   end
 
   always_comb begin : full_check
     full = (size == ARRAY_SIZE);
     for (int i = 0; i < ARRAY_SIZE; i++) begin
-      full = full & bram_o_full[i];  // AND operation to ensure all are full
+      full = full & !bram_o_write_ready[i];  // AND operation to ensure all are full
     end
   end
 
-  assign o_empty = empty;
-  assign o_full  = full;
+  assign o_read_ready = !empty;
+  assign o_write_ready  = !full;
   assign o_data  = level_0_data[0];
 
 endmodule

--- a/hwpq/hybrid_tree/rtl/src/pipelined_bram_tree.sv
+++ b/hwpq/hybrid_tree/rtl/src/pipelined_bram_tree.sv
@@ -13,8 +13,8 @@
           i_wrt - Write/insert command (enqueue operation)
           i_read - Read/pop command (dequeue operation)
           i_data - Input data to be inserted (or used for replace)
-  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
-           o_empty - High when the queue is empty
+  Outputs: o_write_ready - High when the queue has room to accept a write
+           o_read_ready - High when the queue holds data available to read
            o_valid - High when o_data holds a valid output
            o_data - Output data from the highest priority element
 *******************************************************************************/
@@ -30,8 +30,8 @@ module pipelined_bram_tree #(
     input  logic                  i_read,   // Read/pop command
     input  logic [DATA_WIDTH-1:0] i_data,   // Data to be inserted (or used for replace)
     // Outputs
-    output logic                  o_full,   // High if the heap is full
-    output logic                  o_empty,  // High if the heap is empty
+    output logic                  o_write_ready,   // High if the queue can accept a write
+    output logic                  o_read_ready,  // High if the queue has data to read
     output logic                  o_valid,
     output logic [DATA_WIDTH-1:0] o_data    // Output data (popped value)
 );
@@ -443,8 +443,8 @@ module pipelined_bram_tree #(
   //-------------------------------------------------------------------------
   // Assignments for status and output.
   //-------------------------------------------------------------------------
-  assign o_full  = (queue_size >= QUEUE_SIZE);
-  assign o_empty = (queue_size <= 0);
+  assign o_write_ready  = !(queue_size >= QUEUE_SIZE);
+  assign o_read_ready = !(queue_size <= 0);
   assign o_valid = valid;
   assign o_data  = level_0;
 

--- a/hwpq/hybrid_tree/rtl/src/pipelined_bram_tree.sv
+++ b/hwpq/hybrid_tree/rtl/src/pipelined_bram_tree.sv
@@ -8,8 +8,8 @@
                enqueue, dequeue, and replace operations.
   Parameters: QUEUE_SIZE - Maximum number of elements in the sub-tree
               DATA_WIDTH - Bit width of data elements
-  Inputs: CLK - System clock
-          RSTn - Active-low reset signal
+  Inputs: i_CLK - System clock
+          i_RSTn - Active-low reset signal
           i_wrt - Write/insert command (enqueue operation)
           i_read - Read/pop command (dequeue operation)
           i_data - Input data to be inserted (or used for replace)
@@ -23,8 +23,8 @@ module pipelined_bram_tree #(
     parameter integer QUEUE_SIZE = 7,
     parameter integer DATA_WIDTH = 16
 ) (
-    input  logic                  CLK,
-    input  logic                  RSTn,
+    input  logic                  i_CLK,
+    input  logic                  i_RSTn,
     // Inputs
     input  logic                  i_wrt,    // Write/insert command
     input  logic                  i_read,   // Read/pop command
@@ -125,13 +125,13 @@ module pipelined_bram_tree #(
           .WIDTH(DATA_WIDTH),
           .DEPTH((1 << i))
       ) bram_inst (
-          .clka (CLK),
+          .clka (i_CLK),
           .ena  (1'b1),
           .wea  (we_a[i]),
           .addra(addr_a[i]),
           .dia  (din_a[i]),
           .doa  (dout_a[i]),
-          .clkb (CLK),
+          .clkb (i_CLK),
           .enb  (1'b1),
           .web  (we_b[i]),
           .addrb(addr_b[i]),
@@ -160,8 +160,8 @@ module pipelined_bram_tree #(
   // FSM
   //-------------------------------------------------------------------------
 
-  always_ff @(posedge CLK or negedge RSTn) begin : fsm_seq
-    if (!RSTn) begin
+  always_ff @(posedge i_CLK or negedge i_RSTn) begin : fsm_seq
+    if (!i_RSTn) begin
       state <= IDLE;
     end else begin
       state <= next_state;
@@ -234,8 +234,8 @@ module pipelined_bram_tree #(
   // BRAM read & write, heap management
   //-------------------------------------------------------------------------
 
-  always_ff @(posedge CLK or negedge RSTn) begin : bram_seq
-    if (!RSTn) begin
+  always_ff @(posedge i_CLK or negedge i_RSTn) begin : bram_seq
+    if (!i_RSTn) begin
       parent_lvl <= '0;
       parent_idx <= '0;
       level_0 <= '0;
@@ -417,8 +417,8 @@ module pipelined_bram_tree #(
   // Queue size counter
   //-------------------------------------------------------------------------
 
-  always_ff @(posedge CLK or negedge RSTn) begin : queue_size_seq
-    if (!RSTn) begin
+  always_ff @(posedge i_CLK or negedge i_RSTn) begin : queue_size_seq
+    if (!i_RSTn) begin
       queue_size <= 0;
     end else begin
       queue_size <= next_queue_size;

--- a/hwpq/hybrid_tree/rtl/src/pipelined_bram_tree.sv
+++ b/hwpq/hybrid_tree/rtl/src/pipelined_bram_tree.sv
@@ -1,3 +1,24 @@
+/*******************************************************************************
+  Module Name: pipelined_bram_tree
+  Date: 2025/03/20
+  Description: A pipelined BRAM-based max-heap tree used as the sub-tree
+               building block of the hybrid_tree architecture. Levels beyond
+               the register-backed top are stored in block RAM, with an index
+               tracking the currently displaced node between levels. Supports
+               enqueue, dequeue, and replace operations.
+  Parameters: QUEUE_SIZE - Maximum number of elements in the sub-tree
+              DATA_WIDTH - Bit width of data elements
+  Inputs: CLK - System clock
+          RSTn - Active-low reset signal
+          i_wrt - Write/insert command (enqueue operation)
+          i_read - Read/pop command (dequeue operation)
+          i_data - Input data to be inserted (or used for replace)
+  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
+           o_empty - High when the queue is empty
+           o_valid - High when o_data holds a valid output
+           o_data - Output data from the highest priority element
+*******************************************************************************/
+
 module pipelined_bram_tree #(
     parameter integer QUEUE_SIZE = 7,
     parameter integer DATA_WIDTH = 16

--- a/hwpq/register_array/rtl/sim/register_array_tb.sv
+++ b/hwpq/register_array/rtl/sim/register_array_tb.sv
@@ -114,6 +114,8 @@ module register_array_tb;
   // Clock generation: 10ns period
   always #5 CLK <= ~CLK;
 
+  int error_count = 0;
+
   initial begin
     // Initialize signals
     CLK = 0;
@@ -144,16 +146,16 @@ module register_array_tb;
       random_value = $urandom_range(1, 1023);
       enqueue(random_value);
     end
-    assert (o_full) else $error("The queue should be filled by the intialization!");
+    assert (o_full) else begin error_count++; $error("The queue should be filled by the intialization!"); end;
 
     // Test Case 1: Dequeue nodes with ENQ_ENA enabled
     $display("\nTest Case 1: Dequeue Test (ENQ_ENA enabled)");
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
       if (!o_empty) begin
-        assert (o_data == ref_queue_enq_1[0]) else $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+        assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
       end else begin
-        assert (o_data == '0) else $error("Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+        assert (o_data == '0) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -162,16 +164,16 @@ module register_array_tb;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       random_value = $urandom_range(1, 1023);
       enqueue(random_value);
-      assert (o_data == ref_queue_enq_1[0]) else $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+      assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
-    assert (o_full) else $error("The queue should be filled after enqueue!");
+    assert (o_full) else begin error_count++; $error("The queue should be filled after enqueue!"); end;
 
     // Test Case 3: Replace nodes with ENQ_ENA enabled
     $display("\nTest Case 3: Replace Test (ENQ_ENA enabled)");
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       random_value = $urandom_range(1, 1023);
       replace(random_value);
-      assert (o_data == ref_queue_enq_1[0]) else $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+      assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
     
     // Test case 4: Random opertaion for 50 times
@@ -182,20 +184,20 @@ module register_array_tb;
         ENQUEUE: begin
           random_value = $urandom_range(1, 1023);
           enqueue(random_value);
-          assert (o_data == ref_queue_enq_1[0]) else $error("Random Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+          assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Random Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
         end
         DEQUEUE: begin
           dequeue();
           if (!o_empty) begin
-            assert (o_data == ref_queue_enq_1[0]) else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+            assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
           end else begin
-            assert (o_data == '0) else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+            assert (o_data == '0) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
         REPLACE: begin
           random_value = $urandom_range(1, 1023);
           replace(random_value);
-          assert (o_data == ref_queue_enq_1[0]) else $error("Random Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+          assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Random Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
         end
       endcase
     end
@@ -227,13 +229,13 @@ module register_array_tb;
 
     // Test Case 5: Dequeue Test with ENQ_ENA disabled
     $display("\nTest Case 5: Dequeue Test (ENQ_ENA disabled)");
-    assert (o_full) else $error("The queue should be filled by the intialization!");
+    assert (o_full) else begin error_count++; $error("The queue should be filled by the intialization!"); end;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
       if (!o_empty) begin
-        assert (o_data == ref_queue_enq_0[0]) else $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+        assert (o_data == ref_queue_enq_0[0]) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
       end else begin
-        assert (o_data == 'd0) else $error("Dequeue: Node value mismatch -> expected %d, got %d", 'd0, o_data);
+        assert (o_data == 'd0) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", 'd0, o_data); end;
       end
     end
     
@@ -244,9 +246,9 @@ module register_array_tb;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       random_value = $urandom_range(1, 1023);
       enqueue(random_value);
-      assert (o_data == ref_queue_enq_0[0]) else $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+      assert (o_data == ref_queue_enq_0[0]) else begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
     end
-    assert (o_data == o_data_prev) else $error("The queue should not have change!");
+    assert (o_data == o_data_prev) else begin error_count++; $error("The queue should not have change!"); end;
     begin
       bit queues_match;
       bit error_flag;
@@ -262,16 +264,16 @@ module register_array_tb;
           end
         end
       end
-      assert (!error_flag) else $error("The queue should not have change!");
+      assert (!error_flag) else begin error_count++; $error("The queue should not have change!"); end;
     end
-    assert (!o_full && !o_empty) else $error("The queue should not do anything!");
+    assert (!o_full && !o_empty) else begin error_count++; $error("The queue should not do anything!"); end;
 
     // Test Case 7: Test Replace operation with ENQ_ENA disabled
     $display("\nTest Case 7: Replace Test (ENQ_ENA disabled)");
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       random_value = $urandom_range(1, 1023);
       replace(random_value);
-      assert (o_data == ref_queue_enq_0[0]) else $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+      assert (o_data == ref_queue_enq_0[0]) else begin error_count++; $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
     end
     
     // Test case 8: Random opertaion for 50 times
@@ -282,21 +284,26 @@ module register_array_tb;
         DEQUEUE: begin
           dequeue();
           if (!o_empty) begin
-            assert (o_data == ref_queue_enq_0[0]) else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+            assert (o_data == ref_queue_enq_0[0]) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
           end else begin
-            assert (o_data == '0) else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+            assert (o_data == '0) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
         REPLACE: begin
           random_value = $urandom_range(1, 1023);
           replace(random_value);
-          assert (o_data == ref_queue_enq_0[0]) else $error("Random Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+          assert (o_data == ref_queue_enq_0[0]) else begin error_count++; $error("Random Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
         end
       endcase
     end
 
-    $display("\nTest completed!");
-    $finish;
+    if (error_count == 0) begin
+      $display("\nTest completed!");
+      $finish;
+    end else begin
+      $display("\n%0d error(s) detected during simulation.", error_count);
+      $fatal(1, "Test FAILED with %0d error(s).", error_count);
+    end
   end
 
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);

--- a/hwpq/register_array/rtl/sim/register_array_tb.sv
+++ b/hwpq/register_array/rtl/sim/register_array_tb.sv
@@ -309,21 +309,27 @@ module register_array_tb;
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     begin
       if (!o_full) begin
-        if (current_mode == ENABLED) begin
-          i_wrt_ena = 1;
-          i_read_ena = 0;
-          i_data_ena = value;
+        case (current_mode)
+          ENABLED: begin
+            i_wrt_ena = 1;
+            i_read_ena = 0;
+            i_data_ena = value;
 
-          ref_queue_enq_1[ref_queue_enq_1_size] = value;
-          ref_queue_enq_1_size++;
-      
-          rsort_ena();
-        end else if (current_mode == DISABLED) begin
-          i_wrt_dis = 1;
-          i_read_dis = 0;
-          i_data_dis = value;
-//          $display("Enqueue attempt with ENQ_ENA disabled - should have no effect");
-        end
+            ref_queue_enq_1[ref_queue_enq_1_size] = value;
+            ref_queue_enq_1_size++;
+
+            rsort_ena();
+          end
+          DISABLED: begin
+            i_wrt_dis = 1;
+            i_read_dis = 0;
+            i_data_dis = value;
+//            $display("Enqueue attempt with ENQ_ENA disabled - should have no effect");
+          end
+          default: begin
+            $display("Enqueue: Invalid mode, skipping enqueue");
+          end
+        endcase
       end else begin
         $display("Enqueue: Queue full, skipping enqueue");
       end
@@ -339,29 +345,33 @@ module register_array_tb;
   task automatic dequeue();
     begin
       if (!o_empty) begin
-        if (current_mode == ENABLED) begin
-          i_wrt_ena  = 0;
-          i_read_ena = 1;
-          i_data_ena = 0;
+        case (current_mode)
+          ENABLED: begin
+            i_wrt_ena  = 0;
+            i_read_ena = 1;
+            i_data_ena = 0;
 
-          for (int i = 0; i < ref_queue_enq_1_size - 1; i++) begin
-            ref_queue_enq_1[i] = ref_queue_enq_1[i+1];
+            for (int i = 0; i < ref_queue_enq_1_size - 1; i++) begin
+              ref_queue_enq_1[i] = ref_queue_enq_1[i+1];
+            end
+            ref_queue_enq_1[ref_queue_enq_1_size-1] = '0;
+            ref_queue_enq_1_size--;
           end
-          ref_queue_enq_1[ref_queue_enq_1_size-1] = '0; 
-          ref_queue_enq_1_size--;
+          DISABLED: begin
+            i_wrt_dis  = 0;
+            i_read_dis = 1;
+            i_data_dis = 0;
 
-        end else if (current_mode == DISABLED) begin
-          i_wrt_dis  = 0;
-          i_read_dis = 1;
-          i_data_dis = 0;
-
-          for (int i = 0; i < ref_queue_enq_0_size - 1; i++) begin
-            ref_queue_enq_0[i] = ref_queue_enq_0[i+1];
+            for (int i = 0; i < ref_queue_enq_0_size - 1; i++) begin
+              ref_queue_enq_0[i] = ref_queue_enq_0[i+1];
+            end
+            ref_queue_enq_0[ref_queue_enq_0_size-1] = '0;
+            ref_queue_enq_0_size--;
           end
-          ref_queue_enq_0[ref_queue_enq_0_size-1] = '0; 
-          ref_queue_enq_0_size--;
-
-        end
+          default: begin
+            $display("Dequeue: Invalid mode, skipping dequeue");
+          end
+        endcase
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
@@ -377,31 +387,37 @@ module register_array_tb;
 
   task automatic replace(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (current_mode == ENABLED) begin
-        i_wrt_ena  = 1;
-        i_read_ena = 1;
-        i_data_ena = value;
-        if (o_empty) begin
-          ref_queue_enq_1[ref_queue_enq_1_size] = value;
-          ref_queue_enq_1_size++;
-          rsort_ena();
-        end else begin
-          ref_queue_enq_1[0] = value;
-          rsort_ena();
+      case (current_mode)
+        ENABLED: begin
+          i_wrt_ena  = 1;
+          i_read_ena = 1;
+          i_data_ena = value;
+          if (o_empty) begin
+            ref_queue_enq_1[ref_queue_enq_1_size] = value;
+            ref_queue_enq_1_size++;
+            rsort_ena();
+          end else begin
+            ref_queue_enq_1[0] = value;
+            rsort_ena();
+          end
         end
-      end else if (current_mode == DISABLED) begin
-        i_wrt_dis  = 1;
-        i_read_dis = 1;
-        i_data_dis = value;
-        if (o_empty) begin
-          ref_queue_enq_0[ref_queue_enq_0_size] = value;
-          ref_queue_enq_0_size++;
-          rsort_dis();
-        end else begin
-          ref_queue_enq_0[0] = value;
-          rsort_dis();
+        DISABLED: begin
+          i_wrt_dis  = 1;
+          i_read_dis = 1;
+          i_data_dis = value;
+          if (o_empty) begin
+            ref_queue_enq_0[ref_queue_enq_0_size] = value;
+            ref_queue_enq_0_size++;
+            rsort_dis();
+          end else begin
+            ref_queue_enq_0[0] = value;
+            rsort_dis();
+          end
         end
-      end
+        default: begin
+          $display("Replace: Invalid mode, skipping replace");
+        end
+      endcase
       @(posedge CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
@@ -414,15 +430,21 @@ module register_array_tb;
 
   task automatic replace_init(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (current_mode == ENABLED) begin
-        i_wrt_ena  = 1;
-        i_read_ena = 1;
-        i_data_ena = value;
-      end else if (current_mode == DISABLED) begin
-        i_wrt_dis  = 1;
-        i_read_dis = 1;
-        i_data_dis = value;
-      end
+      case (current_mode)
+        ENABLED: begin
+          i_wrt_ena  = 1;
+          i_read_ena = 1;
+          i_data_ena = value;
+        end
+        DISABLED: begin
+          i_wrt_dis  = 1;
+          i_read_dis = 1;
+          i_data_dis = value;
+        end
+        default: begin
+          $display("Replace: Invalid mode, skipping replace");
+        end
+      endcase
       @(posedge CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;

--- a/hwpq/register_array/rtl/sim/register_array_tb.sv
+++ b/hwpq/register_array/rtl/sim/register_array_tb.sv
@@ -332,8 +332,7 @@ module register_array_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK); // should have no effects
+      repeat (2) @(posedge CLK);
     end
   endtask
 
@@ -371,8 +370,8 @@ module register_array_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+
+      repeat (2) @(posedge CLK);
     end
   endtask
 
@@ -408,8 +407,8 @@ module register_array_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+
+      repeat (2) @(posedge CLK);
     end
   endtask
 
@@ -429,8 +428,8 @@ module register_array_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+
+      repeat (2) @(posedge CLK);
     end
   endtask
 

--- a/hwpq/register_array/rtl/sim/register_array_tb.sv
+++ b/hwpq/register_array/rtl/sim/register_array_tb.sv
@@ -114,6 +114,27 @@ module register_array_tb;
   // Clock generation: 10ns period
   always #5 i_CLK <= ~i_CLK;
 
+  // quiescence polling replaces the fixed settle wait
+  logic settled;
+  assign settled = o_write_ready || o_read_ready;
+
+  // Step off the active edge before polling, then poll on the negedge since sampling settled in the same timestep as the posedge
+  // reads it before the DUT's non-blocking updates to queue have propagated
+
+  localparam int SETTLE_TIMEOUT = 10000;
+  task automatic poll_settled();
+    int guard;
+    guard = 0;
+    while (!settled) begin
+      @(negedge i_CLK);
+      guard++;
+      if (guard > SETTLE_TIMEOUT) begin
+        $fatal(1, "poll_settled: DUT never settled after %0d cycles (o_write_ready=%0b o_read_ready=%0b)",
+               SETTLE_TIMEOUT, o_write_ready, o_read_ready);
+      end
+    end
+  endtask
+
   int error_count = 0;
 
   initial begin
@@ -135,6 +156,7 @@ module register_array_tb;
     @(posedge i_CLK);
     i_RSTn = 1;
     @(posedge i_CLK);
+    @(negedge i_CLK);  // enter the negedge contract before any poll
 
     // Test with ENQ_ENA enabled
     $display("\n=== Testing with ENQ_ENA enabled ===");
@@ -211,6 +233,7 @@ module register_array_tb;
     @(posedge i_CLK);
     i_RSTn = 1;
     @(posedge i_CLK);
+    @(negedge i_CLK);
     
     // Initialize queue inside enqueue disabled module
     $display("\nInitializing enqueue disabled module by replacing into it");
@@ -222,9 +245,7 @@ module register_array_tb;
     end
     rsort_dis();
 
-
-
-    repeat (2) @(posedge i_CLK);
+    poll_settled();
 
 
     // Test Case 5: Dequeue Test with ENQ_ENA disabled
@@ -308,6 +329,7 @@ module register_array_tb;
 
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     begin
+      poll_settled();  // the DUT refuses commands while settling
       if (o_write_ready) begin
         case (current_mode)
           ENABLED: begin
@@ -333,17 +355,19 @@ module register_array_tb;
       end else begin
         $display("Enqueue: Queue full, skipping enqueue");
       end
-      @(posedge i_CLK);
+      @(posedge i_CLK);  // DUT captures the command here
+      @(negedge i_CLK);  // release it off the edge
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      repeat (2) @(posedge i_CLK);
+      poll_settled();
     end
   endtask
 
   task automatic dequeue();
     begin
+      poll_settled();
       if (o_read_ready) begin
         case (current_mode)
           ENABLED: begin
@@ -376,17 +400,18 @@ module register_array_tb;
         $display("Dequeue: Queue empty, skipping dequeue");
       end
       @(posedge i_CLK);
+      @(negedge i_CLK); 
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-
-      repeat (2) @(posedge i_CLK);
+      poll_settled();
     end
   endtask
 
   task automatic replace(input logic [DATA_WIDTH-1:0] value);
     begin
+      poll_settled(); 
       case (current_mode)
         ENABLED: begin
           i_wrt_ena  = 1;
@@ -419,17 +444,18 @@ module register_array_tb;
         end
       endcase
       @(posedge i_CLK);
+      @(negedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-
-      repeat (2) @(posedge i_CLK);
+      poll_settled();
     end
   endtask
 
   task automatic replace_init(input logic [DATA_WIDTH-1:0] value);
     begin
+      poll_settled();
       case (current_mode)
         ENABLED: begin
           i_wrt_ena  = 1;
@@ -445,13 +471,13 @@ module register_array_tb;
           $display("Replace: Invalid mode, skipping replace");
         end
       endcase
-      @(posedge i_CLK);
+      @(posedge i_CLK);  
+      @(negedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-
-      repeat (2) @(posedge i_CLK);
+      poll_settled();
     end
   endtask
 

--- a/hwpq/register_array/rtl/sim/register_array_tb.sv
+++ b/hwpq/register_array/rtl/sim/register_array_tb.sv
@@ -20,18 +20,18 @@ module register_array_tb;
   logic [DATA_WIDTH-1:0] i_data_dis;
 
   // Output signals - for ENQ_ENA enabled
-  logic                  o_full_ena;
-  logic                  o_empty_ena;
+  logic                  o_write_ready_ena;
+  logic                  o_read_ready_ena;
   logic [DATA_WIDTH-1:0] o_data_ena;
   
   // Output signals - for ENQ_ENA disabled
-  logic                  o_full_dis;
-  logic                  o_empty_dis;
+  logic                  o_write_ready_dis;
+  logic                  o_read_ready_dis;
   logic [DATA_WIDTH-1:0] o_data_dis;
   
   // Current active outputs for testing
-  logic                  o_full;
-  logic                  o_empty;
+  logic                  o_write_ready;
+  logic                  o_read_ready;
   logic [DATA_WIDTH-1:0] o_data;
   logic [DATA_WIDTH-1:0] o_data_prev;
   
@@ -70,8 +70,8 @@ module register_array_tb;
       .i_wrt(i_wrt_ena),
       .i_read(i_read_ena),
       .i_data(i_data_ena),
-      .o_full(o_full_ena),
-      .o_empty(o_empty_ena),
+      .o_write_ready(o_write_ready_ena),
+      .o_read_ready(o_read_ready_ena),
       .o_data(o_data_ena)
   );
   
@@ -86,26 +86,26 @@ module register_array_tb;
       .i_wrt(i_wrt_dis),
       .i_read(i_read_dis),
       .i_data(i_data_dis),
-      .o_full(o_full_dis),
-      .o_empty(o_empty_dis),
+      .o_write_ready(o_write_ready_dis),
+      .o_read_ready(o_read_ready_dis),
       .o_data(o_data_dis)
   );
 
   always_comb begin : output_signal_switch
     case (current_mode)
       ENABLED : begin
-        o_full = o_full_ena;
-        o_empty = o_empty_ena;
+        o_write_ready = o_write_ready_ena;
+        o_read_ready = o_read_ready_ena;
         o_data = o_data_ena;
       end
       DISABLED : begin
-        o_full = o_full_dis;
-        o_empty = o_empty_dis;
+        o_write_ready = o_write_ready_dis;
+        o_read_ready = o_read_ready_dis;
         o_data = o_data_dis;
       end
       default : begin
-        o_full = o_full_dis;
-        o_empty = o_empty_dis;
+        o_write_ready = o_write_ready_dis;
+        o_read_ready = o_read_ready_dis;
         o_data = o_data_dis;
       end
     endcase
@@ -146,13 +146,13 @@ module register_array_tb;
       random_value = $urandom_range(1, 1023);
       enqueue(random_value);
     end
-    assert (o_full) else begin error_count++; $error("The queue should be filled by the intialization!"); end;
+    assert (!o_write_ready) else begin error_count++; $error("The queue should be filled by the intialization!"); end;
 
     // Test Case 1: Dequeue nodes with ENQ_ENA enabled
     $display("\nTest Case 1: Dequeue Test (ENQ_ENA enabled)");
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
       end else begin
         assert (o_data == '0) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
@@ -166,7 +166,7 @@ module register_array_tb;
       enqueue(random_value);
       assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
-    assert (o_full) else begin error_count++; $error("The queue should be filled after enqueue!"); end;
+    assert (!o_write_ready) else begin error_count++; $error("The queue should be filled after enqueue!"); end;
 
     // Test Case 3: Replace nodes with ENQ_ENA enabled
     $display("\nTest Case 3: Replace Test (ENQ_ENA enabled)");
@@ -188,7 +188,7 @@ module register_array_tb;
         end
         DEQUEUE: begin
           dequeue();
-          if (!o_empty) begin
+          if (o_read_ready) begin
             assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
           end else begin
             assert (o_data == '0) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
@@ -229,10 +229,10 @@ module register_array_tb;
 
     // Test Case 5: Dequeue Test with ENQ_ENA disabled
     $display("\nTest Case 5: Dequeue Test (ENQ_ENA disabled)");
-    assert (o_full) else begin error_count++; $error("The queue should be filled by the intialization!"); end;
+    assert (!o_write_ready) else begin error_count++; $error("The queue should be filled by the intialization!"); end;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue_enq_0[0]) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
       end else begin
         assert (o_data == 'd0) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", 'd0, o_data); end;
@@ -266,7 +266,7 @@ module register_array_tb;
       end
       assert (!error_flag) else begin error_count++; $error("The queue should not have change!"); end;
     end
-    assert (!o_full && !o_empty) else begin error_count++; $error("The queue should not do anything!"); end;
+    assert (o_write_ready && o_read_ready) else begin error_count++; $error("The queue should not do anything!"); end;
 
     // Test Case 7: Test Replace operation with ENQ_ENA disabled
     $display("\nTest Case 7: Replace Test (ENQ_ENA disabled)");
@@ -283,7 +283,7 @@ module register_array_tb;
       case (random_operation)
         DEQUEUE: begin
           dequeue();
-          if (!o_empty) begin
+          if (o_read_ready) begin
             assert (o_data == ref_queue_enq_0[0]) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
           end else begin
             assert (o_data == '0) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
@@ -308,7 +308,7 @@ module register_array_tb;
 
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (!o_full) begin
+      if (o_write_ready) begin
         case (current_mode)
           ENABLED: begin
             i_wrt_ena = 1;
@@ -344,7 +344,7 @@ module register_array_tb;
 
   task automatic dequeue();
     begin
-      if (!o_empty) begin
+      if (o_read_ready) begin
         case (current_mode)
           ENABLED: begin
             i_wrt_ena  = 0;
@@ -392,7 +392,7 @@ module register_array_tb;
           i_wrt_ena  = 1;
           i_read_ena = 1;
           i_data_ena = value;
-          if (o_empty) begin
+          if (!o_read_ready) begin
             ref_queue_enq_1[ref_queue_enq_1_size] = value;
             ref_queue_enq_1_size++;
             rsort_ena();
@@ -405,7 +405,7 @@ module register_array_tb;
           i_wrt_dis  = 1;
           i_read_dis = 1;
           i_data_dis = value;
-          if (o_empty) begin
+          if (!o_read_ready) begin
             ref_queue_enq_0[ref_queue_enq_0_size] = value;
             ref_queue_enq_0_size++;
             rsort_dis();

--- a/hwpq/register_array/rtl/sim/register_array_tb.sv
+++ b/hwpq/register_array/rtl/sim/register_array_tb.sv
@@ -6,8 +6,8 @@ module register_array_tb;
   localparam int DATA_WIDTH = 16;
 
   // Clock and reset signals
-  logic                 CLK;
-  logic                 RSTn;
+  logic                 i_CLK;
+  logic                 i_RSTn;
 
   // Input signals - for ENQ_ENA enabled
   logic                  i_wrt_ena;
@@ -65,8 +65,8 @@ module register_array_tb;
       .QUEUE_SIZE(QUEUE_SIZE),
       .DATA_WIDTH(DATA_WIDTH)
   ) u_RegisterArray_ena (
-      .i_CLK(CLK),
-      .i_RSTn(RSTn),
+      .i_CLK(i_CLK),
+      .i_RSTn(i_RSTn),
       .i_wrt(i_wrt_ena),
       .i_read(i_read_ena),
       .i_data(i_data_ena),
@@ -81,8 +81,8 @@ module register_array_tb;
       .QUEUE_SIZE(QUEUE_SIZE),
       .DATA_WIDTH(DATA_WIDTH)
   ) u_RegisterArray_dis (
-      .i_CLK(CLK),
-      .i_RSTn(RSTn),
+      .i_CLK(i_CLK),
+      .i_RSTn(i_RSTn),
       .i_wrt(i_wrt_dis),
       .i_read(i_read_dis),
       .i_data(i_data_dis),
@@ -112,13 +112,13 @@ module register_array_tb;
   end
 
   // Clock generation: 10ns period
-  always #5 CLK <= ~CLK;
+  always #5 i_CLK <= ~i_CLK;
 
   int error_count = 0;
 
   initial begin
     // Initialize signals
-    CLK = 0;
+    i_CLK = 0;
     i_wrt_ena = 0;
     i_read_ena = 0;
     i_data_ena = 0;
@@ -131,10 +131,10 @@ module register_array_tb;
     ref_queue_prev = {};
 
     // Reset the modules
-    RSTn = 0;
-    @(posedge CLK);
-    RSTn = 1;
-    @(posedge CLK);
+    i_RSTn = 0;
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    @(posedge i_CLK);
 
     // Test with ENQ_ENA enabled
     $display("\n=== Testing with ENQ_ENA enabled ===");
@@ -207,10 +207,10 @@ module register_array_tb;
     current_mode = DISABLED;
 
     // Reset the modules
-    RSTn = 0;
-    @(posedge CLK);
-    RSTn = 1;
-    @(posedge CLK);
+    i_RSTn = 0;
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    @(posedge i_CLK);
     
     // Initialize queue inside enqueue disabled module
     $display("\nInitializing enqueue disabled module by replacing into it");
@@ -224,7 +224,7 @@ module register_array_tb;
 
 
 
-    repeat (2) @(posedge CLK);
+    repeat (2) @(posedge i_CLK);
 
 
     // Test Case 5: Dequeue Test with ENQ_ENA disabled
@@ -333,12 +333,12 @@ module register_array_tb;
       end else begin
         $display("Enqueue: Queue full, skipping enqueue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      repeat (2) @(posedge CLK);
+      repeat (2) @(posedge i_CLK);
     end
   endtask
 
@@ -375,13 +375,13 @@ module register_array_tb;
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
 
-      repeat (2) @(posedge CLK);
+      repeat (2) @(posedge i_CLK);
     end
   endtask
 
@@ -418,13 +418,13 @@ module register_array_tb;
           $display("Replace: Invalid mode, skipping replace");
         end
       endcase
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
 
-      repeat (2) @(posedge CLK);
+      repeat (2) @(posedge i_CLK);
     end
   endtask
 
@@ -445,13 +445,13 @@ module register_array_tb;
           $display("Replace: Invalid mode, skipping replace");
         end
       endcase
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
 
-      repeat (2) @(posedge CLK);
+      repeat (2) @(posedge i_CLK);
     end
   endtask
 

--- a/hwpq/register_array/rtl/src/register_array.sv
+++ b/hwpq/register_array/rtl/src/register_array.sv
@@ -62,11 +62,14 @@ module register_array #(
     end
   endgenerate
 
-  assign enqueue = (ENQ_ENA && i_wrt && !i_read) ? 'b1 : 'b0;
-  assign dequeue = (!i_wrt && i_read) ? 'b1 : 'b0;
+  // Enqueue and dequeue are refused when the queue cannot honor them
+  assign enqueue = (ENQ_ENA && i_wrt && !i_read) ? o_write_ready : 'b0;
+  assign dequeue = (!i_wrt && i_read) ? o_read_ready : 'b0;
   assign replace = (i_wrt && i_read) ? 'b1 : 'b0;
   assign full = (size >= QUEUE_SIZE) ? 'b1 : 'b0;
   assign empty = (size <= '0) ? 'b1 : 'b0;
+
+  // head valid every cycle since queue_operation folds the command into stage1
   assign o_write_ready = !full;
   assign o_read_ready = !empty;
   assign o_data = queue[0];

--- a/hwpq/register_array/rtl/src/register_array.sv
+++ b/hwpq/register_array/rtl/src/register_array.sv
@@ -1,5 +1,26 @@
 `default_nettype none
 
+/*******************************************************************************
+  Module Name: register_array
+  Date: 2026/06/21
+  Description: A priority queue implementation that stores elements in a flat
+               register array rather than a hierarchical heap. A replace
+               operation overwrites the leftmost entry with the new item,
+               followed by two phases of array-wide compare-and-swap (even-
+               indexed then odd-indexed neighbor pairs) to restore order.
+  Parameters: ENQ_ENA - Enables the enqueue datapath when set
+              QUEUE_SIZE - Maximum number of elements in the priority queue
+              DATA_WIDTH - Bit width of data elements
+  Inputs: i_CLK - System clock
+          i_RSTn - Active-low reset signal
+          i_wrt - Write/insert command (enqueue/replace operation)
+          i_read - Read/pop command (dequeue/replace operation)
+          i_data - Input data to be enqueued (or used for replace)
+  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
+           o_empty - High when the queue is empty
+           o_data - Output data from the highest priority element
+*******************************************************************************/
+
 module register_array #(
     parameter bit ENQ_ENA = 0,  // if user would like to enable enqueue
     parameter int QUEUE_SIZE = 4,  // size of the queue

--- a/hwpq/register_array/rtl/src/register_array.sv
+++ b/hwpq/register_array/rtl/src/register_array.sv
@@ -16,8 +16,8 @@
           i_wrt - Write/insert command (enqueue/replace operation)
           i_read - Read/pop command (dequeue/replace operation)
           i_data - Input data to be enqueued (or used for replace)
-  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
-           o_empty - High when the queue is empty
+  Outputs: o_write_ready - High when the queue has room to accept a write
+           o_read_ready - High when the queue holds data available to read
            o_data - Output data from the highest priority element
 *******************************************************************************/
 
@@ -33,8 +33,8 @@ module register_array #(
     input var  logic                  i_read,   // pop
     input var  logic [DATA_WIDTH-1:0] i_data,   // input data
     // Outputs
-    output var logic                  o_full,   // queue full
-    output var logic                  o_empty,  // queue empty
+    output var logic                  o_write_ready,   // High if the queue can accept a write
+    output var logic                  o_read_ready,  // High if the queue has data to read
     output var logic [DATA_WIDTH-1:0] o_data    // queue head
 );
 
@@ -67,8 +67,8 @@ module register_array #(
   assign replace = (i_wrt && i_read) ? 'b1 : 'b0;
   assign full = (size >= QUEUE_SIZE) ? 'b1 : 'b0;
   assign empty = (size <= '0) ? 'b1 : 'b0;
-  assign o_full = full;
-  assign o_empty = empty;
+  assign o_write_ready = !full;
+  assign o_read_ready = !empty;
   assign o_data = queue[0];
 
   always_ff @(posedge i_CLK or negedge i_RSTn) begin

--- a/hwpq/register_array_pipelined/rtl/sim/register_array_pipelined_tb.sv
+++ b/hwpq/register_array_pipelined/rtl/sim/register_array_pipelined_tb.sv
@@ -379,8 +379,7 @@ module register_array_pipelined_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK); // should have no effects
+      repeat (2) @(posedge CLK);
     end
   endtask
 
@@ -418,8 +417,8 @@ module register_array_pipelined_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+
+      repeat (2) @(posedge CLK);
     end
   endtask
 
@@ -456,8 +455,8 @@ module register_array_pipelined_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+
+      repeat (2) @(posedge CLK);
     end
   endtask
 

--- a/hwpq/register_array_pipelined/rtl/sim/register_array_pipelined_tb.sv
+++ b/hwpq/register_array_pipelined/rtl/sim/register_array_pipelined_tb.sv
@@ -6,8 +6,8 @@ module register_array_pipelined_tb;
   localparam int DATA_WIDTH = 16;
 
   // Clock and reset signals
-  logic                  CLK;
-  logic                  RSTn;
+  logic                  i_CLK;
+  logic                  i_RSTn;
 
   // Input signals - for ENQ_ENA enabled
   logic                  i_wrt_ena;
@@ -68,8 +68,8 @@ module register_array_pipelined_tb;
       .QUEUE_SIZE(QUEUE_SIZE),
       .DATA_WIDTH(DATA_WIDTH)
   ) u_RegisterArray_ena (
-      .i_CLK  (CLK),
-      .i_RSTn (RSTn),
+      .i_CLK  (i_CLK),
+      .i_RSTn (i_RSTn),
       .i_wrt  (i_wrt_ena),
       .i_read (i_read_ena),
       .i_data (i_data_ena),
@@ -84,8 +84,8 @@ module register_array_pipelined_tb;
       .QUEUE_SIZE(QUEUE_SIZE),
       .DATA_WIDTH(DATA_WIDTH)
   ) u_RegisterArray_dis (
-      .i_CLK  (CLK),
-      .i_RSTn (RSTn),
+      .i_CLK  (i_CLK),
+      .i_RSTn (i_RSTn),
       .i_wrt  (i_wrt_dis),
       .i_read (i_read_dis),
       .i_data (i_data_dis),
@@ -115,13 +115,13 @@ module register_array_pipelined_tb;
   end
 
   // Clock generation: 10ns period
-  always #5 CLK <= ~CLK;
+  always #5 i_CLK <= ~i_CLK;
 
   int error_count = 0;
 
   initial begin
     // Initialize signals
-    CLK = 0;
+    i_CLK = 0;
     i_wrt_ena = 0;
     i_read_ena = 0;
     i_data_ena = 0;
@@ -134,10 +134,10 @@ module register_array_pipelined_tb;
     ref_queue_prev = {};
 
     // Reset the modules
-    RSTn = 0;
-    @(posedge CLK);
-    RSTn = 1;
-    @(posedge CLK);
+    i_RSTn = 0;
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    @(posedge i_CLK);
 
     // Test with ENQ_ENA enabled
     $display("\n=== Testing with ENQ_ENA enabled ===");
@@ -237,10 +237,10 @@ module register_array_pipelined_tb;
     current_mode = DISABLED;
 
     // Reset the modules
-    RSTn = 0;
-    @(posedge CLK);
-    RSTn = 1;
-    @(posedge CLK);
+    i_RSTn = 0;
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    @(posedge i_CLK);
 
     // Initialize queue inside enqueue disabled module
     $display("\nInitializing enqueue disabled module by replacing into it");
@@ -380,12 +380,12 @@ module register_array_pipelined_tb;
       end else begin
         $display("Enqueue: Queue full, skipping enqueue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      repeat (2) @(posedge CLK);
+      repeat (2) @(posedge i_CLK);
     end
   endtask
 
@@ -422,13 +422,13 @@ module register_array_pipelined_tb;
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
 
-      repeat (2) @(posedge CLK);
+      repeat (2) @(posedge i_CLK);
     end
   endtask
 
@@ -466,13 +466,13 @@ module register_array_pipelined_tb;
           $display("Replace: Invalid mode, skipping replace");
         end
       endcase
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
 
-      repeat (2) @(posedge CLK);
+      repeat (2) @(posedge i_CLK);
     end
   endtask
 
@@ -493,13 +493,13 @@ module register_array_pipelined_tb;
           $display("Replace: Invalid mode, skipping replace");
         end
       endcase
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
 
-      @(posedge CLK);
+      @(posedge i_CLK);
     end
   endtask
 

--- a/hwpq/register_array_pipelined/rtl/sim/register_array_pipelined_tb.sv
+++ b/hwpq/register_array_pipelined/rtl/sim/register_array_pipelined_tb.sv
@@ -117,6 +117,8 @@ module register_array_pipelined_tb;
   // Clock generation: 10ns period
   always #5 CLK <= ~CLK;
 
+  int error_count = 0;
+
   initial begin
     // Initialize signals
     CLK = 0;
@@ -147,7 +149,7 @@ module register_array_pipelined_tb;
       enqueue(random_value);
     end
     assert (o_full)
-    else $error("The queue should be filled by the intialization!");
+    else begin error_count++; $error("The queue should be filled by the intialization!"); end;
 
     // Test Case 1: Dequeue nodes with ENQ_ENA enabled
     $display("\nTest Case 1: Dequeue Test (ENQ_ENA enabled)");
@@ -156,10 +158,10 @@ module register_array_pipelined_tb;
       if (!o_empty) begin
         assert (o_data == ref_queue_enq_1[0])
         else
-          $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+          begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
       end else begin
         assert (o_data == '0)
-        else $error("Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+        else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -170,10 +172,10 @@ module register_array_pipelined_tb;
       enqueue(random_value);
       assert (o_data == ref_queue_enq_1[0])
       else
-        $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+        begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
     assert (o_full)
-    else $error("The queue should be filled after enqueue!");
+    else begin error_count++; $error("The queue should be filled after enqueue!"); end;
 
     // Test Case 3: Replace nodes with ENQ_ENA enabled
     $display("\nTest Case 3: Replace Test (ENQ_ENA enabled)");
@@ -182,7 +184,7 @@ module register_array_pipelined_tb;
       replace(random_value);
       assert (o_data == ref_queue_enq_1[0])
       else
-        $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+        begin error_count++; $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
 
     // Test case 4: Random opertaion for 50 times
@@ -195,25 +197,25 @@ module register_array_pipelined_tb;
           enqueue(random_value);
           assert (o_data == ref_queue_enq_1[0])
           else
-            $error(
+            begin error_count++; $error(
                 "Random Enqueue: Node value mismatch -> expected %d, got %d",
                 ref_queue_enq_1[0],
                 o_data
-            );
+            ); end;
         end
         DEQUEUE: begin
           dequeue();
           if (!o_empty) begin
             assert (o_data == ref_queue_enq_1[0])
             else
-              $error(
+              begin error_count++; $error(
                   "Random Dequeue: Node value mismatch -> expected %d, got %d",
                   ref_queue_enq_1[0],
                   o_data
-              );
+              ); end;
           end else begin
             assert (o_data == '0)
-            else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+            else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
         REPLACE: begin
@@ -221,11 +223,11 @@ module register_array_pipelined_tb;
           replace(random_value);
           assert (o_data == ref_queue_enq_1[0])
           else
-            $error(
+            begin error_count++; $error(
                 "Random Replace: Node value mismatch -> expected %d, got %d",
                 ref_queue_enq_1[0],
                 o_data
-            );
+            ); end;
         end
       endcase
     end
@@ -252,16 +254,16 @@ module register_array_pipelined_tb;
 
     // Test Case 5: Dequeue Test with ENQ_ENA disabled
     $display("\nTest Case 5: Dequeue Test (ENQ_ENA disabled)");
-    assert (o_full) else $error("The queue should be filled by the intialization!");
+    assert (o_full) else begin error_count++; $error("The queue should be filled by the intialization!"); end;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue_enq_0[0])
         else
-          $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+          begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
       end else begin
         assert (o_data == 'd0)
-        else $error("Dequeue: Node value mismatch -> expected %d, got %d", 'd0, o_data);
+        else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", 'd0, o_data); end;
       end
     end
 
@@ -274,10 +276,10 @@ module register_array_pipelined_tb;
       enqueue(random_value);
       assert (o_data == ref_queue_enq_0[0])
       else
-        $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+        begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
     end
     assert (o_data == o_data_prev)
-    else $error("The queue should not have change!");
+    else begin error_count++; $error("The queue should not have change!"); end;
     begin
       bit queues_match;
       bit error_flag;
@@ -293,10 +295,10 @@ module register_array_pipelined_tb;
           end
         end
       end
-      assert (!error_flag) else $error("The queue should not have change!");
+      assert (!error_flag) else begin error_count++; $error("The queue should not have change!"); end;
     end
     assert (!o_full && !o_empty)
-    else $error("The queue should not do anything!");
+    else begin error_count++; $error("The queue should not do anything!"); end;
 
     // Test Case 7: Test Replace operation with ENQ_ENA disabled
     $display("\nTest Case 7: Replace Test (ENQ_ENA disabled)");
@@ -305,7 +307,7 @@ module register_array_pipelined_tb;
       replace(random_value);
       assert (o_data == ref_queue_enq_0[0])
       else
-        $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+        begin error_count++; $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
     end
 
     // Test case 8: Random opertaion for 50 times
@@ -318,14 +320,14 @@ module register_array_pipelined_tb;
           if (!o_empty) begin
             assert (o_data == ref_queue_enq_0[0])
             else
-              $error(
+              begin error_count++; $error(
                   "Random Dequeue: Node value mismatch -> expected %d, got %d",
                   ref_queue_enq_0[0],
                   o_data
-              );
+              ); end;
           end else begin
             assert (o_data == '0)
-            else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+            else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
         REPLACE: begin
@@ -333,17 +335,22 @@ module register_array_pipelined_tb;
           replace(random_value);
           assert (o_data == ref_queue_enq_0[0])
           else
-            $error(
+            begin error_count++; $error(
                 "Random Replace: Node value mismatch -> expected %d, got %d",
                 ref_queue_enq_0[0],
                 o_data
-            );
+            ); end;
         end
       endcase
     end
 
-    $display("\nTest completed!");
-    $finish;
+    if (error_count == 0) begin
+      $display("\nTest completed!");
+      $finish;
+    end else begin
+      $display("\n%0d error(s) detected during simulation.", error_count);
+      $fatal(1, "Test FAILED with %0d error(s).", error_count);
+    end
   end
 
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);

--- a/hwpq/register_array_pipelined/rtl/sim/register_array_pipelined_tb.sv
+++ b/hwpq/register_array_pipelined/rtl/sim/register_array_pipelined_tb.sv
@@ -20,18 +20,18 @@ module register_array_pipelined_tb;
   logic [DATA_WIDTH-1:0] i_data_dis;
 
   // Output signals - for ENQ_ENA enabled
-  logic                  o_full_ena;
-  logic                  o_empty_ena;
+  logic                  o_write_ready_ena;
+  logic                  o_read_ready_ena;
   logic [DATA_WIDTH-1:0] o_data_ena;
 
   // Output signals - for ENQ_ENA disabled
-  logic                  o_full_dis;
-  logic                  o_empty_dis;
+  logic                  o_write_ready_dis;
+  logic                  o_read_ready_dis;
   logic [DATA_WIDTH-1:0] o_data_dis;
 
   // Current active outputs for testing
-  logic                  o_full;
-  logic                  o_empty;
+  logic                  o_write_ready;
+  logic                  o_read_ready;
   logic [DATA_WIDTH-1:0] o_data;
   logic [DATA_WIDTH-1:0] o_data_prev;
 
@@ -73,8 +73,8 @@ module register_array_pipelined_tb;
       .i_wrt  (i_wrt_ena),
       .i_read (i_read_ena),
       .i_data (i_data_ena),
-      .o_full (o_full_ena),
-      .o_empty(o_empty_ena),
+      .o_write_ready (o_write_ready_ena),
+      .o_read_ready(o_read_ready_ena),
       .o_data (o_data_ena)
   );
 
@@ -89,26 +89,26 @@ module register_array_pipelined_tb;
       .i_wrt  (i_wrt_dis),
       .i_read (i_read_dis),
       .i_data (i_data_dis),
-      .o_full (o_full_dis),
-      .o_empty(o_empty_dis),
+      .o_write_ready (o_write_ready_dis),
+      .o_read_ready(o_read_ready_dis),
       .o_data (o_data_dis)
   );
 
   always_comb begin : output_signal_switch
     case (current_mode)
       ENABLED: begin
-        o_full  = o_full_ena;
-        o_empty = o_empty_ena;
+        o_write_ready  = o_write_ready_ena;
+        o_read_ready = o_read_ready_ena;
         o_data  = o_data_ena;
       end
       DISABLED: begin
-        o_full  = o_full_dis;
-        o_empty = o_empty_dis;
+        o_write_ready  = o_write_ready_dis;
+        o_read_ready = o_read_ready_dis;
         o_data  = o_data_dis;
       end
       default: begin
-        o_full  = o_full_dis;
-        o_empty = o_empty_dis;
+        o_write_ready  = o_write_ready_dis;
+        o_read_ready = o_read_ready_dis;
         o_data  = o_data_dis;
       end
     endcase
@@ -148,14 +148,14 @@ module register_array_pipelined_tb;
       random_value = DATA_WIDTH'(($urandom & ((1 << DATA_WIDTH) - 1)) % 1025);
       enqueue(random_value);
     end
-    assert (o_full)
+    assert (!o_write_ready)
     else begin error_count++; $error("The queue should be filled by the intialization!"); end;
 
     // Test Case 1: Dequeue nodes with ENQ_ENA enabled
     $display("\nTest Case 1: Dequeue Test (ENQ_ENA enabled)");
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue_enq_1[0])
         else
           begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
@@ -174,7 +174,7 @@ module register_array_pipelined_tb;
       else
         begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
-    assert (o_full)
+    assert (!o_write_ready)
     else begin error_count++; $error("The queue should be filled after enqueue!"); end;
 
     // Test Case 3: Replace nodes with ENQ_ENA enabled
@@ -205,7 +205,7 @@ module register_array_pipelined_tb;
         end
         DEQUEUE: begin
           dequeue();
-          if (!o_empty) begin
+          if (o_read_ready) begin
             assert (o_data == ref_queue_enq_1[0])
             else
               begin error_count++; $error(
@@ -254,10 +254,10 @@ module register_array_pipelined_tb;
 
     // Test Case 5: Dequeue Test with ENQ_ENA disabled
     $display("\nTest Case 5: Dequeue Test (ENQ_ENA disabled)");
-    assert (o_full) else begin error_count++; $error("The queue should be filled by the intialization!"); end;
+    assert (!o_write_ready) else begin error_count++; $error("The queue should be filled by the intialization!"); end;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue_enq_0[0])
         else
           begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
@@ -297,7 +297,7 @@ module register_array_pipelined_tb;
       end
       assert (!error_flag) else begin error_count++; $error("The queue should not have change!"); end;
     end
-    assert (!o_full && !o_empty)
+    assert (o_write_ready && o_read_ready)
     else begin error_count++; $error("The queue should not do anything!"); end;
 
     // Test Case 7: Test Replace operation with ENQ_ENA disabled
@@ -317,7 +317,7 @@ module register_array_pipelined_tb;
       case (random_operation)
         DEQUEUE: begin
           dequeue();
-          if (!o_empty) begin
+          if (o_read_ready) begin
             assert (o_data == ref_queue_enq_0[0])
             else
               begin error_count++; $error(
@@ -355,7 +355,7 @@ module register_array_pipelined_tb;
 
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (!o_full) begin
+      if (o_write_ready) begin
         case (current_mode)
           ENABLED: begin
             i_wrt_ena = 1;
@@ -391,7 +391,7 @@ module register_array_pipelined_tb;
 
   task automatic dequeue();
     begin
-      if (!o_empty) begin
+      if (o_read_ready) begin
         case (current_mode)
           ENABLED: begin
             i_wrt_ena  = 0;
@@ -439,7 +439,7 @@ module register_array_pipelined_tb;
           i_wrt_ena  = 1;
           i_read_ena = 1;
           i_data_ena = value;
-          if (o_empty) begin
+          if (!o_read_ready) begin
             ref_queue_enq_1[ref_queue_enq_1_size] = value;
             ref_queue_enq_1_size++;
 
@@ -453,7 +453,7 @@ module register_array_pipelined_tb;
           i_wrt_dis  = 1;
           i_read_dis = 1;
           i_data_dis = value;
-          if (o_empty) begin
+          if (!o_read_ready) begin
             ref_queue_enq_0[ref_queue_enq_0_size] = value;
             ref_queue_enq_0_size++;
             rsort_dis();

--- a/hwpq/register_array_pipelined/rtl/sim/register_array_pipelined_tb.sv
+++ b/hwpq/register_array_pipelined/rtl/sim/register_array_pipelined_tb.sv
@@ -116,6 +116,22 @@ module register_array_pipelined_tb;
 
   // Clock generation: 10ns period
   always #5 i_CLK <= ~i_CLK;
+  logic settled;
+  assign settled = o_write_ready || o_read_ready;
+
+  localparam int SETTLE_TIMEOUT = 10000;
+  task automatic poll_settled();
+    int guard;
+    guard = 0;
+    while (!settled) begin
+      @(negedge i_CLK);
+      guard++;
+      if (guard > SETTLE_TIMEOUT) begin
+        $fatal(1, "poll_settled: DUT never settled after %0d cycles (o_write_ready=%0b o_read_ready=%0b)",
+               SETTLE_TIMEOUT, o_write_ready, o_read_ready);
+      end
+    end
+  endtask
 
   int error_count = 0;
 
@@ -138,6 +154,7 @@ module register_array_pipelined_tb;
     @(posedge i_CLK);
     i_RSTn = 1;
     @(posedge i_CLK);
+    @(negedge i_CLK);
 
     // Test with ENQ_ENA enabled
     $display("\n=== Testing with ENQ_ENA enabled ===");
@@ -241,6 +258,7 @@ module register_array_pipelined_tb;
     @(posedge i_CLK);
     i_RSTn = 1;
     @(posedge i_CLK);
+    @(negedge i_CLK); 
 
     // Initialize queue inside enqueue disabled module
     $display("\nInitializing enqueue disabled module by replacing into it");
@@ -355,6 +373,7 @@ module register_array_pipelined_tb;
 
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     begin
+      poll_settled();
       if (o_write_ready) begin
         case (current_mode)
           ENABLED: begin
@@ -380,17 +399,19 @@ module register_array_pipelined_tb;
       end else begin
         $display("Enqueue: Queue full, skipping enqueue");
       end
-      @(posedge i_CLK);
+      @(posedge i_CLK); 
+      @(negedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      repeat (2) @(posedge i_CLK);
+      poll_settled();
     end
   endtask
 
   task automatic dequeue();
     begin
+      poll_settled();
       if (o_read_ready) begin
         case (current_mode)
           ENABLED: begin
@@ -422,18 +443,19 @@ module register_array_pipelined_tb;
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
-      @(posedge i_CLK);
+      @(posedge i_CLK); 
+      @(negedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-
-      repeat (2) @(posedge i_CLK);
+      poll_settled();
     end
   endtask
 
   task automatic replace(input logic [DATA_WIDTH-1:0] value);
     begin
+      poll_settled();
       case (current_mode)
         ENABLED: begin
           i_wrt_ena  = 1;
@@ -467,17 +489,18 @@ module register_array_pipelined_tb;
         end
       endcase
       @(posedge i_CLK);
+      @(negedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-
-      repeat (2) @(posedge i_CLK);
+      poll_settled();
     end
   endtask
 
   task automatic replace_init(input logic [DATA_WIDTH-1:0] value);
     begin
+      poll_settled(); 
       case (current_mode)
         ENABLED: begin
           i_wrt_ena  = 1;
@@ -494,12 +517,12 @@ module register_array_pipelined_tb;
         end
       endcase
       @(posedge i_CLK);
+      @(negedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-
-      @(posedge i_CLK);
+      poll_settled();
     end
   endtask
 

--- a/hwpq/register_array_pipelined/rtl/sim/register_array_pipelined_tb.sv
+++ b/hwpq/register_array_pipelined/rtl/sim/register_array_pipelined_tb.sv
@@ -356,21 +356,27 @@ module register_array_pipelined_tb;
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     begin
       if (!o_full) begin
-        if (current_mode == ENABLED) begin
-          i_wrt_ena = 1;
-          i_read_ena = 0;
-          i_data_ena = value;
+        case (current_mode)
+          ENABLED: begin
+            i_wrt_ena = 1;
+            i_read_ena = 0;
+            i_data_ena = value;
 
-          ref_queue_enq_1[ref_queue_enq_1_size] = value;
-          ref_queue_enq_1_size++;
-      
-          rsort_ena();
-        end else if (current_mode == DISABLED) begin
-          i_wrt_dis = 1;
-          i_read_dis = 0;
-          i_data_dis = value;
-//          $display("Enqueue attempt with ENQ_ENA disabled - should have no effect");
-        end
+            ref_queue_enq_1[ref_queue_enq_1_size] = value;
+            ref_queue_enq_1_size++;
+
+            rsort_ena();
+          end
+          DISABLED: begin
+            i_wrt_dis = 1;
+            i_read_dis = 0;
+            i_data_dis = value;
+//            $display("Enqueue attempt with ENQ_ENA disabled - should have no effect");
+          end
+          default: begin
+            $display("Enqueue: Invalid mode, skipping enqueue");
+          end
+        endcase
       end else begin
         $display("Enqueue: Queue full, skipping enqueue");
       end
@@ -386,29 +392,33 @@ module register_array_pipelined_tb;
   task automatic dequeue();
     begin
       if (!o_empty) begin
-        if (current_mode == ENABLED) begin
-          i_wrt_ena  = 0;
-          i_read_ena = 1;
-          i_data_ena = 0;
+        case (current_mode)
+          ENABLED: begin
+            i_wrt_ena  = 0;
+            i_read_ena = 1;
+            i_data_ena = 0;
 
-          for (int i = 0; i < ref_queue_enq_1_size - 1; i++) begin
-            ref_queue_enq_1[i] = ref_queue_enq_1[i+1];
+            for (int i = 0; i < ref_queue_enq_1_size - 1; i++) begin
+              ref_queue_enq_1[i] = ref_queue_enq_1[i+1];
+            end
+            ref_queue_enq_1[ref_queue_enq_1_size-1] = '0;
+            ref_queue_enq_1_size--;
           end
-          ref_queue_enq_1[ref_queue_enq_1_size-1] = '0; 
-          ref_queue_enq_1_size--;
+          DISABLED: begin
+            i_wrt_dis  = 0;
+            i_read_dis = 1;
+            i_data_dis = 0;
 
-        end else if (current_mode == DISABLED) begin
-          i_wrt_dis  = 0;
-          i_read_dis = 1;
-          i_data_dis = 0;
-
-          for (int i = 0; i < ref_queue_enq_0_size - 1; i++) begin
-            ref_queue_enq_0[i] = ref_queue_enq_0[i+1];
+            for (int i = 0; i < ref_queue_enq_0_size - 1; i++) begin
+              ref_queue_enq_0[i] = ref_queue_enq_0[i+1];
+            end
+            ref_queue_enq_0[ref_queue_enq_0_size-1] = '0;
+            ref_queue_enq_0_size--;
           end
-          ref_queue_enq_0[ref_queue_enq_0_size-1] = '0; 
-          ref_queue_enq_0_size--;
-
-        end
+          default: begin
+            $display("Dequeue: Invalid mode, skipping dequeue");
+          end
+        endcase
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
@@ -424,32 +434,38 @@ module register_array_pipelined_tb;
 
   task automatic replace(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (current_mode == ENABLED) begin
-        i_wrt_ena  = 1;
-        i_read_ena = 1;
-        i_data_ena = value;
-        if (o_empty) begin
-          ref_queue_enq_1[ref_queue_enq_1_size] = value;
-          ref_queue_enq_1_size++;
-          
-          rsort_ena();
-        end else begin
-          ref_queue_enq_1[0] = value;
-          rsort_ena();
+      case (current_mode)
+        ENABLED: begin
+          i_wrt_ena  = 1;
+          i_read_ena = 1;
+          i_data_ena = value;
+          if (o_empty) begin
+            ref_queue_enq_1[ref_queue_enq_1_size] = value;
+            ref_queue_enq_1_size++;
+
+            rsort_ena();
+          end else begin
+            ref_queue_enq_1[0] = value;
+            rsort_ena();
+          end
         end
-      end else if (current_mode == DISABLED) begin
-        i_wrt_dis  = 1;
-        i_read_dis = 1;
-        i_data_dis = value;
-        if (o_empty) begin
-          ref_queue_enq_0[ref_queue_enq_0_size] = value;
-          ref_queue_enq_0_size++;
-          rsort_dis();
-        end else begin
-          ref_queue_enq_0[0] = value;
-          rsort_dis();
+        DISABLED: begin
+          i_wrt_dis  = 1;
+          i_read_dis = 1;
+          i_data_dis = value;
+          if (o_empty) begin
+            ref_queue_enq_0[ref_queue_enq_0_size] = value;
+            ref_queue_enq_0_size++;
+            rsort_dis();
+          end else begin
+            ref_queue_enq_0[0] = value;
+            rsort_dis();
+          end
         end
-      end
+        default: begin
+          $display("Replace: Invalid mode, skipping replace");
+        end
+      endcase
       @(posedge CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
@@ -462,22 +478,28 @@ module register_array_pipelined_tb;
 
   task automatic replace_init(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (current_mode == ENABLED) begin
-        i_wrt_ena  = 1;
-        i_read_ena = 1;
-        i_data_ena = value;
-      end else if (current_mode == DISABLED) begin
-        i_wrt_dis  = 1;
-        i_read_dis = 1;
-        i_data_dis = value;
-      end
+      case (current_mode)
+        ENABLED: begin
+          i_wrt_ena  = 1;
+          i_read_ena = 1;
+          i_data_ena = value;
+        end
+        DISABLED: begin
+          i_wrt_dis  = 1;
+          i_read_dis = 1;
+          i_data_dis = value;
+        end
+        default: begin
+          $display("Replace: Invalid mode, skipping replace");
+        end
+      endcase
       @(posedge CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) @(posedge CLK);
-      else if (current_mode == DISABLED) @(posedge CLK);
+
+      @(posedge CLK);
     end
   endtask
 

--- a/hwpq/register_array_pipelined/rtl/src/register_array_pipelined.sv
+++ b/hwpq/register_array_pipelined/rtl/src/register_array_pipelined.sv
@@ -1,5 +1,26 @@
 `default_nettype none
 
+/*******************************************************************************
+  Module Name: register_array_pipelined
+  Date: 2026/06/21
+  Description: A pipelined version of the register array priority queue that
+               splits the array-wide compare-and-swap operation across two
+               clock cycles (even-indexed pairs, then odd-indexed pairs) to
+               shorten the combinational path and reach higher clock
+               frequencies.
+  Parameters: ENQ_ENA - Enables the enqueue datapath when set
+              QUEUE_SIZE - Maximum number of elements in the priority queue
+              DATA_WIDTH - Bit width of data elements
+  Inputs: i_CLK - System clock
+          i_RSTn - Active-low reset signal
+          i_wrt - Write/insert command (enqueue/replace operation)
+          i_read - Read/pop command (dequeue/replace operation)
+          i_data - Input data to be enqueued (or used for replace)
+  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
+           o_empty - High when the queue is empty
+           o_data - Output data from the highest priority element
+*******************************************************************************/
+
 module register_array_pipelined #(
     parameter bit ENQ_ENA = 1,  // if user would like to enable enqueue
     parameter int QUEUE_SIZE = 4,  // size of the queue

--- a/hwpq/register_array_pipelined/rtl/src/register_array_pipelined.sv
+++ b/hwpq/register_array_pipelined/rtl/src/register_array_pipelined.sv
@@ -16,8 +16,8 @@
           i_wrt - Write/insert command (enqueue/replace operation)
           i_read - Read/pop command (dequeue/replace operation)
           i_data - Input data to be enqueued (or used for replace)
-  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
-           o_empty - High when the queue is empty
+  Outputs: o_write_ready - High when the queue has room to accept a write
+           o_read_ready - High when the queue holds data available to read
            o_data - Output data from the highest priority element
 *******************************************************************************/
 
@@ -33,8 +33,8 @@ module register_array_pipelined #(
     input var  logic                  i_read,   // pop
     input var  logic [DATA_WIDTH-1:0] i_data,   // input data
     // Outputs
-    output var logic                  o_full,   // queue full
-    output var logic                  o_empty,  // queue empty
+    output var logic                  o_write_ready,   // High if the queue can accept a write
+    output var logic                  o_read_ready,  // High if the queue has data to read
     output var logic [DATA_WIDTH-1:0] o_data    // queue head
 );
 
@@ -67,8 +67,8 @@ module register_array_pipelined #(
   assign replace = (i_wrt && i_read) ? 'b1 : 'b0;
   assign full = (size >= QUEUE_SIZE) ? 'b1 : 'b0;
   assign empty = (size <= '0) ? 'b1 : 'b0;
-  assign o_full = full;
-  assign o_empty = empty;
+  assign o_write_ready = !full;
+  assign o_read_ready = !empty;
   assign o_data = queue[0];
 
   always_ff @(posedge i_CLK or negedge i_RSTn) begin

--- a/hwpq/register_array_pipelined/rtl/src/register_array_pipelined.sv
+++ b/hwpq/register_array_pipelined/rtl/src/register_array_pipelined.sv
@@ -51,6 +51,7 @@ module register_array_pipelined #(
   logic [$clog2(QUEUE_SIZE):0] size, next_size;
 
   logic full, empty, enqueue, dequeue, replace, even_cycle_flag, next_even_cycle_flag;
+  logic head_valid, can_accept;
 
   generate
     for (genvar i = 0; i < QUEUE_SIZE; i++) begin : l_gen_reset_queue
@@ -62,13 +63,16 @@ module register_array_pipelined #(
     end
   endgenerate
 
-  assign enqueue = (ENQ_ENA && i_wrt && !i_read) ? 'b1 : 'b0;
-  assign dequeue = (!i_wrt && i_read) ? 'b1 : 'b0;
-  assign replace = (i_wrt && i_read) ? 'b1 : 'b0;
+  assign enqueue = (ENQ_ENA && i_wrt && !i_read) ? o_write_ready : 'b0;
+  assign dequeue = (!i_wrt && i_read) ? o_read_ready : 'b0;
+  assign replace = (i_wrt && i_read) ? (can_accept && head_valid) : 'b0;
   assign full = (size >= QUEUE_SIZE) ? 'b1 : 'b0;
   assign empty = (size <= '0) ? 'b1 : 'b0;
-  assign o_write_ready = !full;
-  assign o_read_ready = !empty;
+
+  //   o_write_ready - can you take another value?
+  //   o_read_ready  - is o_data trustworthy?
+  assign o_write_ready = !full && can_accept;
+  assign o_read_ready = !empty && head_valid;
   assign o_data = queue[0];
 
   always_ff @(posedge i_CLK or negedge i_RSTn) begin
@@ -189,5 +193,9 @@ module register_array_pipelined #(
       end
     endcase
   end
+
+
+  assign head_valid = (queue[0] >= queue[1]);
+  assign can_accept = head_valid;
 
 endmodule

--- a/hwpq/register_tree/rtl/sim/register_tree_tb.sv
+++ b/hwpq/register_tree/rtl/sim/register_tree_tb.sv
@@ -114,6 +114,8 @@ module register_tree_tb;
   // Clock generation: 10ns period
   always #5 CLK <= ~CLK;
 
+  int error_count = 0;
+
   initial begin
     // Initialize signals
     CLK = 0;
@@ -143,16 +145,16 @@ module register_tree_tb;
       random_value = $urandom_range(1, 1023);
       enqueue(random_value);
     end
-    assert (o_full) else $error("The queue should be filled by the intialization!");
+    assert (o_full) else begin error_count++; $error("The queue should be filled by the intialization!"); end;
 
     // Test Case 1: Dequeue nodes with ENQ_ENA enabled
     $display("\nTest Case 1: Dequeue Test (ENQ_ENA enabled)");
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
       if (!o_empty) begin
-        assert (o_data == ref_queue_enq_1[0]) else $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+        assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
       end else begin
-        assert (o_data == '0) else $error("Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+        assert (o_data == '0) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -161,16 +163,16 @@ module register_tree_tb;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       random_value = $urandom_range(1, 1023);
       enqueue(random_value);
-      assert (o_data == ref_queue_enq_1[0]) else $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+      assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
-    assert (o_full) else $error("The queue should be filled after enqueue!");
+    assert (o_full) else begin error_count++; $error("The queue should be filled after enqueue!"); end;
 
     // Test Case 3: Replace nodes with ENQ_ENA enabled
     $display("\nTest Case 3: Replace Test (ENQ_ENA enabled)");
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       random_value = $urandom_range(1, 1023);
       replace(random_value);
-      assert (o_data == ref_queue_enq_1[0]) else $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+      assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
 
     // Test case 4: Random opertaion for 50 times
@@ -181,20 +183,20 @@ module register_tree_tb;
         ENQUEUE: begin
           random_value = $urandom_range(1, 1023);
           enqueue(random_value);
-          assert (o_data == ref_queue_enq_1[0]) else $error("Random Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+          assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Random Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
         end
         DEQUEUE: begin
           dequeue();
           if (!o_empty) begin
-            assert (o_data == ref_queue_enq_1[0]) else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+            assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
           end else begin
-            assert (o_data == '0) else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+            assert (o_data == '0) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
         REPLACE: begin
           random_value = $urandom_range(1, 1023);
           replace(random_value);
-          assert (o_data == ref_queue_enq_1[0]) else $error("Random Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+          assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Random Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
         end
       endcase
     end
@@ -224,16 +226,16 @@ module register_tree_tb;
     // Test Case 4: Dequeue Test with ENQ_ENA disabled
     $display("\nTest Case 4: Dequeue Test (ENQ_ENA disabled)");
     assert (o_full)
-    else $error("The queue should be filled by the intialization!");
+    else begin error_count++; $error("The queue should be filled by the intialization!"); end;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue_enq_0[0])
         else
-          $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+          begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
       end else begin
         assert (o_data == 'd0)
-        else $error("Dequeue: Node value mismatch -> expected %d, got %d", 'd0, o_data);
+        else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", 'd0, o_data); end;
       end
     end
 
@@ -246,9 +248,9 @@ module register_tree_tb;
       enqueue(random_value);
       assert (o_data == ref_queue_enq_0[0])
       else
-        $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+        begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
     end
-    assert (o_data == o_data_prev) else $error("The queue should not have change!");
+    assert (o_data == o_data_prev) else begin error_count++; $error("The queue should not have change!"); end;
     begin
       bit queues_match;
       bit error_flag;
@@ -264,9 +266,9 @@ module register_tree_tb;
           end
         end
       end
-      assert (!error_flag) else $error("The queue should not have change!");
+      assert (!error_flag) else begin error_count++; $error("The queue should not have change!"); end;
     end
-    assert (!o_full && !o_empty) else $error("The queue should not do anything!");
+    assert (!o_full && !o_empty) else begin error_count++; $error("The queue should not do anything!"); end;
 
     // Test Case 6: Test Replace operation with ENQ_ENA disabled
     $display("\nTest Case 6: Replace Test (ENQ_ENA disabled)");
@@ -275,7 +277,7 @@ module register_tree_tb;
       replace(random_value);
       assert (o_data == ref_queue_enq_0[0])
       else
-        $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+        begin error_count++; $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
     end
 
     // Test case 8: Random opertaion for 50 times
@@ -288,14 +290,14 @@ module register_tree_tb;
           if (!o_empty) begin
             assert (o_data == ref_queue_enq_0[0])
             else
-              $error(
+              begin error_count++; $error(
                   "Random Dequeue: Node value mismatch -> expected %d, got %d",
                   ref_queue_enq_0[0],
                   o_data
-              );
+              ); end;
           end else begin
             assert (o_data == '0)
-            else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+            else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
         REPLACE: begin
@@ -303,17 +305,22 @@ module register_tree_tb;
           replace(random_value);
           assert (o_data == ref_queue_enq_0[0])
           else
-            $error(
+            begin error_count++; $error(
                 "Random Replace: Node value mismatch -> expected %d, got %d",
                 ref_queue_enq_0[0],
                 o_data
-            );
+            ); end;
         end
       endcase
     end
 
-    $display("\nTest completed!");
-    $finish;
+    if (error_count == 0) begin
+      $display("\nTest completed!");
+      $finish;
+    end else begin
+      $display("\n%0d error(s) detected during simulation.", error_count);
+      $fatal(1, "Test FAILED with %0d error(s).", error_count);
+    end
   end
 
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);

--- a/hwpq/register_tree/rtl/sim/register_tree_tb.sv
+++ b/hwpq/register_tree/rtl/sim/register_tree_tb.sv
@@ -6,8 +6,8 @@ module register_tree_tb;
   localparam int DATA_WIDTH = 16;
 
   // Clock and reset signals
-  logic                 CLK;
-  logic                 RSTn;
+  logic                 i_CLK;
+  logic                 i_RSTn;
 
   // Input signals - for ENQ_ENA enabled
   logic                  i_wrt_ena;
@@ -65,8 +65,8 @@ module register_tree_tb;
       .QUEUE_SIZE(QUEUE_SIZE),
       .DATA_WIDTH(DATA_WIDTH)
   ) u_RegisterTree_ena (
-      .i_CLK(CLK),
-      .i_RSTn(RSTn),
+      .i_CLK(i_CLK),
+      .i_RSTn(i_RSTn),
       .i_wrt(i_wrt_ena),
       .i_read(i_read_ena),
       .i_data(i_data_ena),
@@ -81,8 +81,8 @@ module register_tree_tb;
       .QUEUE_SIZE(QUEUE_SIZE),
       .DATA_WIDTH(DATA_WIDTH)
   ) u_RegisterTree_dis (
-      .i_CLK(CLK),
-      .i_RSTn(RSTn),
+      .i_CLK(i_CLK),
+      .i_RSTn(i_RSTn),
       .i_wrt(i_wrt_dis),
       .i_read(i_read_dis),
       .i_data(i_data_dis),
@@ -112,13 +112,13 @@ module register_tree_tb;
   end
 
   // Clock generation: 10ns period
-  always #5 CLK <= ~CLK;
+  always #5 i_CLK <= ~i_CLK;
 
   int error_count = 0;
 
   initial begin
     // Initialize signals
-    CLK = 0;
+    i_CLK = 0;
     i_wrt_ena = 0;
     i_read_ena = 0;
     i_data_ena = 0;
@@ -131,10 +131,10 @@ module register_tree_tb;
     ref_queue_prev = {};
 
     // Reset the modules
-    RSTn = 0;
-    @(posedge CLK);
-    RSTn = 1;
-    @(posedge CLK);
+    i_RSTn = 0;
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    @(posedge i_CLK);
 
     // Test with ENQ_ENA enabled
     $display("\n=== Testing with ENQ_ENA enabled ===");
@@ -206,10 +206,10 @@ module register_tree_tb;
     $display("\n=== Testing with ENQ_ENA disabled ===");
     current_mode = DISABLED;
 
-    RSTn = 0;
-    @(posedge CLK);
-    RSTn = 1;
-    @(posedge CLK);
+    i_RSTn = 0;
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    @(posedge i_CLK);
 
     // Initialize queue inside enqueue disabled module
     $display("\nInitializing enqueue disabled module by replacing into it");
@@ -221,7 +221,7 @@ module register_tree_tb;
     end
     rsort_dis();
 
-    repeat (4) @(posedge CLK);
+    repeat (4) @(posedge i_CLK);
 
     // Test Case 4: Dequeue Test with ENQ_ENA disabled
     $display("\nTest Case 4: Dequeue Test (ENQ_ENA disabled)");
@@ -349,17 +349,17 @@ module register_tree_tb;
       end else begin
         $display("Enqueue: Queue full, skipping enqueue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
       case (current_mode)
         ENABLED: begin
-          repeat ($clog2(QUEUE_SIZE)) @(posedge CLK);
+          repeat ($clog2(QUEUE_SIZE)) @(posedge i_CLK);
         end
         DISABLED: begin
-          repeat (2) @(posedge CLK); // should have no effects
+          repeat (2) @(posedge i_CLK); // should have no effects
         end
         default: begin
           $display("Enqueue: Invalid mode, skipping enqueue");
@@ -400,13 +400,13 @@ module register_tree_tb;
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
       
-      repeat (2) @(posedge CLK);
+      repeat (2) @(posedge i_CLK);
     end
   endtask
 
@@ -441,12 +441,12 @@ module register_tree_tb;
         end
       end
       endcase
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      repeat (2) @(posedge CLK); 
+      repeat (2) @(posedge i_CLK); 
     end  
   endtask
 
@@ -464,12 +464,12 @@ module register_tree_tb;
           i_data_dis = value;
         end
       endcase
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      repeat (2) @(posedge CLK);
+      repeat (2) @(posedge i_CLK);
     end
   endtask
 

--- a/hwpq/register_tree/rtl/sim/register_tree_tb.sv
+++ b/hwpq/register_tree/rtl/sim/register_tree_tb.sv
@@ -20,18 +20,18 @@ module register_tree_tb;
   logic [DATA_WIDTH-1:0] i_data_dis;
 
   // Output signals - for ENQ_ENA enabled
-  logic                  o_full_ena;
-  logic                  o_empty_ena;
+  logic                  o_write_ready_ena;
+  logic                  o_read_ready_ena;
   logic [DATA_WIDTH-1:0] o_data_ena;
   
   // Output signals - for ENQ_ENA disabled
-  logic                  o_full_dis;
-  logic                  o_empty_dis;
+  logic                  o_write_ready_dis;
+  logic                  o_read_ready_dis;
   logic [DATA_WIDTH-1:0] o_data_dis;
   
   // Current active outputs for testing
-  logic                  o_full;
-  logic                  o_empty;
+  logic                  o_write_ready;
+  logic                  o_read_ready;
   logic [DATA_WIDTH-1:0] o_data;
   logic [DATA_WIDTH-1:0] o_data_prev;
   
@@ -70,8 +70,8 @@ module register_tree_tb;
       .i_wrt(i_wrt_ena),
       .i_read(i_read_ena),
       .i_data(i_data_ena),
-      .o_full(o_full_ena),
-      .o_empty(o_empty_ena),
+      .o_write_ready(o_write_ready_ena),
+      .o_read_ready(o_read_ready_ena),
       .o_data(o_data_ena)
   );
   
@@ -86,26 +86,26 @@ module register_tree_tb;
       .i_wrt(i_wrt_dis),
       .i_read(i_read_dis),
       .i_data(i_data_dis),
-      .o_full(o_full_dis),
-      .o_empty(o_empty_dis),
+      .o_write_ready(o_write_ready_dis),
+      .o_read_ready(o_read_ready_dis),
       .o_data(o_data_dis)
   );
 
   always_comb begin : output_signal_switch
     case (current_mode)
       ENABLED : begin
-        o_full = o_full_ena;
-        o_empty = o_empty_ena;
+        o_write_ready = o_write_ready_ena;
+        o_read_ready = o_read_ready_ena;
         o_data = o_data_ena;
       end
       DISABLED : begin
-        o_full = o_full_dis;
-        o_empty = o_empty_dis;
+        o_write_ready = o_write_ready_dis;
+        o_read_ready = o_read_ready_dis;
         o_data = o_data_dis;
       end
       default : begin
-        o_full = o_full_dis;
-        o_empty = o_empty_dis;
+        o_write_ready = o_write_ready_dis;
+        o_read_ready = o_read_ready_dis;
         o_data = o_data_dis;
       end
     endcase
@@ -145,13 +145,13 @@ module register_tree_tb;
       random_value = $urandom_range(1, 1023);
       enqueue(random_value);
     end
-    assert (o_full) else begin error_count++; $error("The queue should be filled by the intialization!"); end;
+    assert (!o_write_ready) else begin error_count++; $error("The queue should be filled by the intialization!"); end;
 
     // Test Case 1: Dequeue nodes with ENQ_ENA enabled
     $display("\nTest Case 1: Dequeue Test (ENQ_ENA enabled)");
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
       end else begin
         assert (o_data == '0) else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
@@ -165,7 +165,7 @@ module register_tree_tb;
       enqueue(random_value);
       assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
-    assert (o_full) else begin error_count++; $error("The queue should be filled after enqueue!"); end;
+    assert (!o_write_ready) else begin error_count++; $error("The queue should be filled after enqueue!"); end;
 
     // Test Case 3: Replace nodes with ENQ_ENA enabled
     $display("\nTest Case 3: Replace Test (ENQ_ENA enabled)");
@@ -187,7 +187,7 @@ module register_tree_tb;
         end
         DEQUEUE: begin
           dequeue();
-          if (!o_empty) begin
+          if (o_read_ready) begin
             assert (o_data == ref_queue_enq_1[0]) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
           end else begin
             assert (o_data == '0) else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
@@ -225,11 +225,11 @@ module register_tree_tb;
 
     // Test Case 4: Dequeue Test with ENQ_ENA disabled
     $display("\nTest Case 4: Dequeue Test (ENQ_ENA disabled)");
-    assert (o_full)
+    assert (!o_write_ready)
     else begin error_count++; $error("The queue should be filled by the intialization!"); end;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue_enq_0[0])
         else
           begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
@@ -268,7 +268,7 @@ module register_tree_tb;
       end
       assert (!error_flag) else begin error_count++; $error("The queue should not have change!"); end;
     end
-    assert (!o_full && !o_empty) else begin error_count++; $error("The queue should not do anything!"); end;
+    assert (o_write_ready && o_read_ready) else begin error_count++; $error("The queue should not do anything!"); end;
 
     // Test Case 6: Test Replace operation with ENQ_ENA disabled
     $display("\nTest Case 6: Replace Test (ENQ_ENA disabled)");
@@ -287,7 +287,7 @@ module register_tree_tb;
       case (random_operation)
         DEQUEUE: begin
           dequeue();
-          if (!o_empty) begin
+          if (o_read_ready) begin
             assert (o_data == ref_queue_enq_0[0])
             else
               begin error_count++; $error(
@@ -325,7 +325,7 @@ module register_tree_tb;
 
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (!o_full) begin
+      if (o_write_ready) begin
         case (current_mode)
           ENABLED: begin
             i_wrt_ena = 1;
@@ -370,7 +370,7 @@ module register_tree_tb;
 
   task automatic dequeue();
     begin
-      if (!o_empty) begin
+      if (o_read_ready) begin
         case (current_mode)
         ENABLED: begin        
           i_wrt_ena  = 0;
@@ -417,7 +417,7 @@ module register_tree_tb;
         i_wrt_ena  = 1;
         i_read_ena = 1;
         i_data_ena = value;
-        if (o_empty) begin
+        if (!o_read_ready) begin
           ref_queue_enq_1[ref_queue_enq_1_size] = value;
           ref_queue_enq_1_size++;
           
@@ -431,7 +431,7 @@ module register_tree_tb;
         i_wrt_dis  = 1;
         i_read_dis = 1;
         i_data_dis = value;
-        if (o_empty) begin
+        if (!o_read_ready) begin
           ref_queue_enq_0[ref_queue_enq_0_size] = value;
           ref_queue_enq_0_size++;
           rsort_dis();

--- a/hwpq/register_tree/rtl/sim/register_tree_tb.sv
+++ b/hwpq/register_tree/rtl/sim/register_tree_tb.sv
@@ -114,6 +114,23 @@ module register_tree_tb;
   // Clock generation: 10ns period
   always #5 i_CLK <= ~i_CLK;
 
+  logic settled;
+  assign settled = o_write_ready || o_read_ready;
+
+  localparam int SETTLE_TIMEOUT = 10000;
+  task automatic poll_settled();
+    int guard;
+    guard = 0;
+    while (!settled) begin
+      @(negedge i_CLK);
+      guard++;
+      if (guard > SETTLE_TIMEOUT) begin
+        $fatal(1, "poll_settled: DUT never settled after %0d cycles (o_write_ready=%0b o_read_ready=%0b)",
+               SETTLE_TIMEOUT, o_write_ready, o_read_ready);
+      end
+    end
+  endtask
+
   int error_count = 0;
 
   initial begin
@@ -135,6 +152,7 @@ module register_tree_tb;
     @(posedge i_CLK);
     i_RSTn = 1;
     @(posedge i_CLK);
+    @(negedge i_CLK);
 
     // Test with ENQ_ENA enabled
     $display("\n=== Testing with ENQ_ENA enabled ===");
@@ -210,6 +228,7 @@ module register_tree_tb;
     @(posedge i_CLK);
     i_RSTn = 1;
     @(posedge i_CLK);
+    @(negedge i_CLK);
 
     // Initialize queue inside enqueue disabled module
     $display("\nInitializing enqueue disabled module by replacing into it");
@@ -221,7 +240,7 @@ module register_tree_tb;
     end
     rsort_dis();
 
-    repeat (4) @(posedge i_CLK);
+    poll_settled();
 
     // Test Case 4: Dequeue Test with ENQ_ENA disabled
     $display("\nTest Case 4: Dequeue Test (ENQ_ENA disabled)");
@@ -325,6 +344,7 @@ module register_tree_tb;
 
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     begin
+      poll_settled();
       if (o_write_ready) begin
         case (current_mode)
           ENABLED: begin
@@ -350,26 +370,18 @@ module register_tree_tb;
         $display("Enqueue: Queue full, skipping enqueue");
       end
       @(posedge i_CLK);
+      @(negedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      case (current_mode)
-        ENABLED: begin
-          repeat ($clog2(QUEUE_SIZE)) @(posedge i_CLK);
-        end
-        DISABLED: begin
-          repeat (2) @(posedge i_CLK); // should have no effects
-        end
-        default: begin
-          $display("Enqueue: Invalid mode, skipping enqueue");
-        end
-      endcase
+      poll_settled();
     end
   endtask
 
   task automatic dequeue();
     begin
+      poll_settled();
       if (o_read_ready) begin
         case (current_mode)
         ENABLED: begin        
@@ -401,17 +413,18 @@ module register_tree_tb;
         $display("Dequeue: Queue empty, skipping dequeue");
       end
       @(posedge i_CLK);
+      @(negedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      
-      repeat (2) @(posedge i_CLK);
+      poll_settled();
     end
   endtask
 
   task automatic replace(input logic [DATA_WIDTH-1:0] value);
     begin
+      poll_settled();
       case (current_mode)
       ENABLED: begin
         i_wrt_ena  = 1;
@@ -442,16 +455,18 @@ module register_tree_tb;
       end
       endcase
       @(posedge i_CLK);
+      @(negedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      repeat (2) @(posedge i_CLK); 
-    end  
+      poll_settled();
+    end
   endtask
 
   task automatic replace_init(input logic [DATA_WIDTH-1:0] value);
     begin
+      poll_settled();
       case(current_mode)
         ENABLED: begin
           i_wrt_ena  = 1;
@@ -465,11 +480,12 @@ module register_tree_tb;
         end
       endcase
       @(posedge i_CLK);
+      @(negedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      repeat (2) @(posedge i_CLK);
+      poll_settled();
     end
   endtask
 

--- a/hwpq/register_tree/rtl/sim/register_tree_tb.sv
+++ b/hwpq/register_tree/rtl/sim/register_tree_tb.sv
@@ -326,21 +326,26 @@ module register_tree_tb;
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     begin
       if (!o_full) begin
-        if (current_mode == ENABLED) begin
-          i_wrt_ena = 1;
-          i_read_ena = 0;
-          i_data_ena = value;
+        case (current_mode)
+          ENABLED: begin
+            i_wrt_ena = 1;
+            i_read_ena = 0;
+            i_data_ena = value;
 
-          ref_queue_enq_1[ref_queue_enq_1_size] = value;
-          ref_queue_enq_1_size++;
-      
-          rsort_ena();
-        end else if (current_mode == DISABLED) begin
-          i_wrt_dis = 1;
-          i_read_dis = 0;
-          i_data_dis = value;
-//          $display("Enqueue attempt with ENQ_ENA disabled - should have no effect");
-        end
+            ref_queue_enq_1[ref_queue_enq_1_size] = value;
+            ref_queue_enq_1_size++;
+        
+            rsort_ena();
+          end
+          DISABLED: begin
+            i_wrt_dis = 1;
+            i_read_dis = 0;
+            i_data_dis = value;
+          end
+          default: begin
+            $display("Enqueue: Invalid mode, skipping enqueue");
+          end 
+          endcase
       end else begin
         $display("Enqueue: Queue full, skipping enqueue");
       end
@@ -349,15 +354,25 @@ module register_tree_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat ($clog2(QUEUE_SIZE)) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK); // should have no effects
+      case (current_mode)
+        ENABLED: begin
+          repeat ($clog2(QUEUE_SIZE)) @(posedge CLK);
+        end
+        DISABLED: begin
+          repeat (2) @(posedge CLK); // should have no effects
+        end
+        default: begin
+          $display("Enqueue: Invalid mode, skipping enqueue");
+        end
+      endcase
     end
   endtask
 
   task automatic dequeue();
     begin
       if (!o_empty) begin
-        if (current_mode == ENABLED) begin
+        case (current_mode)
+        ENABLED: begin        
           i_wrt_ena  = 0;
           i_read_ena = 1;
           i_data_ena = 0;
@@ -367,8 +382,8 @@ module register_tree_tb;
           end
           ref_queue_enq_1[ref_queue_enq_1_size-1] = '0; 
           ref_queue_enq_1_size--;
-
-        end else if (current_mode == DISABLED) begin
+        end 
+        DISABLED: begin
           i_wrt_dis  = 0;
           i_read_dis = 1;
           i_data_dis = 0;
@@ -378,8 +393,10 @@ module register_tree_tb;
           end
           ref_queue_enq_0[ref_queue_enq_0_size-1] = '0; 
           ref_queue_enq_0_size--;
-
         end
+        default:
+          $display("Invalid option, skipping dequeue");
+        endcase
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
@@ -395,7 +412,8 @@ module register_tree_tb;
 
   task automatic replace(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (current_mode == ENABLED) begin
+      case (current_mode)
+      ENABLED: begin
         i_wrt_ena  = 1;
         i_read_ena = 1;
         i_data_ena = value;
@@ -408,7 +426,8 @@ module register_tree_tb;
           ref_queue_enq_1[0] = value;
           rsort_ena();
         end
-      end else if (current_mode == DISABLED) begin
+      end 
+      DISABLED: begin
         i_wrt_dis  = 1;
         i_read_dis = 1;
         i_data_dis = value;
@@ -421,6 +440,7 @@ module register_tree_tb;
           rsort_dis();
         end
       end
+      endcase
       @(posedge CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
@@ -432,15 +452,18 @@ module register_tree_tb;
 
   task automatic replace_init(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (current_mode == ENABLED) begin
-        i_wrt_ena  = 1;
-        i_read_ena = 1;
-        i_data_ena = value;
-      end else if (current_mode == DISABLED) begin
-        i_wrt_dis  = 1;
-        i_read_dis = 1;
-        i_data_dis = value;
-      end
+      case(current_mode)
+        ENABLED: begin
+          i_wrt_ena  = 1;
+          i_read_ena = 1;
+          i_data_ena = value;
+        end
+        DISABLED: begin
+          i_wrt_dis  = 1;
+          i_read_dis = 1;
+          i_data_dis = value;
+        end
+      endcase
       @(posedge CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;

--- a/hwpq/register_tree/rtl/sim/register_tree_tb.sv
+++ b/hwpq/register_tree/rtl/sim/register_tree_tb.sv
@@ -388,8 +388,8 @@ module register_tree_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+      
+      repeat (2) @(posedge CLK);
     end
   endtask
 
@@ -426,9 +426,8 @@ module register_tree_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
-    end
+      repeat (2) @(posedge CLK); 
+    end  
   endtask
 
   task automatic replace_init(input logic [DATA_WIDTH-1:0] value);
@@ -447,8 +446,7 @@ module register_tree_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+      repeat (2) @(posedge CLK);
     end
   endtask
 

--- a/hwpq/register_tree/rtl/src/register_tree.sv
+++ b/hwpq/register_tree/rtl/src/register_tree.sv
@@ -17,8 +17,8 @@
           i_wrt - Write/insert command (enqueue/replace operation)
           i_read - Read/pop command (dequeue/replace operation)
           i_data - Input data to be enqueued (or used for replace)
-  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
-           o_empty - High when the queue is empty
+  Outputs: o_write_ready - High when the queue has room to accept a write
+           o_read_ready - High when the queue holds data available to read
            o_data - Output data from the highest priority element
 *******************************************************************************/
 
@@ -35,8 +35,8 @@ module register_tree #(
     input var logic i_read,
     input var logic [DATA_WIDTH-1:0] i_data,
     // Outputs
-    output var logic o_full,
-    output var logic o_empty,
+    output var logic o_write_ready,
+    output var logic o_read_ready,
     output var logic [DATA_WIDTH-1:0] o_data
 );
 
@@ -101,8 +101,8 @@ module register_tree #(
   // Size counter signals
   assign empty = (size <= 0);
   assign full = (size >= QUEUE_SIZE);
-  assign o_full = full;
-  assign o_empty = empty;
+  assign o_write_ready = !full;
+  assign o_read_ready = !empty;
   assign o_data = queue[0];
 
   //----------------------------------------------------------------------

--- a/hwpq/register_tree/rtl/src/register_tree.sv
+++ b/hwpq/register_tree/rtl/src/register_tree.sv
@@ -45,6 +45,12 @@ module register_tree #(
   //----------------------------------------------------------------------
   localparam int TREE_DEPTH = $clog2(QUEUE_SIZE);  // depth of the tree
   localparam int NODES_NEEDED = (1 << TREE_DEPTH) - 1;  // number of nodes needed to initialize
+  // Worst-case settle cycles: enqueue climbs (~TREE_DEPTH/2, two levels/cycle),
+  // dequeue/replace sink and finish in one cycle
+  localparam int CLIMB_CYCLES = (TREE_DEPTH + 2) / 2;
+  localparam int SINK_CYCLES  = 1;
+  localparam int SETTLE_MAX   = (CLIMB_CYCLES > SINK_CYCLES) ? CLIMB_CYCLES : SINK_CYCLES;
+  localparam int CNT_W        = $clog2(SETTLE_MAX + 1);
 
   //----------------------------------------------------------------------
   // Internal Registers and Wires
@@ -59,7 +65,11 @@ module register_tree #(
 
   // Control signals
   logic enqueue, dequeue, replace;
-  
+  logic head_valid, can_accept;
+
+  // Settle countdown (see the settled-detector section below)
+  logic [CNT_W-1:0] settle_cnt, next_settle_cnt;
+
   // Results of each operation - calculated in parallel
   logic [DATA_WIDTH-1:0] swap_result[NODES_NEEDED];
   logic [DATA_WIDTH-1:0] next_queue[NODES_NEEDED];
@@ -94,15 +104,16 @@ module register_tree #(
   //----------------------------------------------------------------------
   // Signals assignments
   //----------------------------------------------------------------------
-  // Control signal assignment
-  assign enqueue = ENQ_ENA && i_wrt && !i_read; // Only enable enqueue if ENQ_ENA is high
-  assign dequeue = !i_wrt && i_read;
-  assign replace = i_wrt && i_read;
+  // A command is refused unless the queue can honor it (this also gates size).
+  // Enqueue/dequeue gate on full/empty; replace pops-and-pushes so needs neither.
+  assign enqueue = ENQ_ENA && i_wrt && !i_read && o_write_ready;
+  assign dequeue = !i_wrt && i_read && o_read_ready;
+  assign replace = i_wrt && i_read && can_accept && head_valid;
   // Size counter signals
   assign empty = (size <= 0);
   assign full = (size >= QUEUE_SIZE);
-  assign o_write_ready = !full;
-  assign o_read_ready = !empty;
+  assign o_write_ready = !full && can_accept;
+  assign o_read_ready  = !empty && head_valid;
   assign o_data = queue[0];
 
   //----------------------------------------------------------------------
@@ -286,12 +297,51 @@ module register_tree #(
         queue[i] <= reset_queue[i];
       end
       size            <= 0;
+      settle_cnt      <= '0;  // reset queue is settled
     end else begin
       for (int i = 0; i < NODES_NEEDED; i++) begin
         queue[i] <= next_queue[i];
       end
       size            <= next_size;
+      settle_cnt      <= next_settle_cnt;
     end
   end
+
+  // head_valid is a compare against a counter flop, not an O(N) heap scan, to
+  // keep the detector off the critical path. No comb loop: settle_cnt is a flop.
+  always_comb begin : calculate_next_settle_cnt
+    if (enqueue) begin
+      next_settle_cnt = CLIMB_CYCLES[CNT_W-1:0];
+    end else if (dequeue || replace) begin
+      next_settle_cnt = SINK_CYCLES[CNT_W-1:0];
+    end else if (settle_cnt != 0) begin
+      next_settle_cnt = settle_cnt - 1'b1;
+    end else begin
+      next_settle_cnt = '0;
+    end
+  end
+
+  assign head_valid = (settle_cnt == 0);
+
+  // Data-adaptive alternatives (release earlier, but put a cone on the critical
+  // path). O(1) root-local is sound only without enqueue (a climber can outrank
+  // the root while hidden below it); O(N) invariant covers enqueue too.
+  //
+  //   assign head_valid = (NODES_NEEDED < 2 || queue[0] >= queue[1]) &&
+  //                       (NODES_NEEDED < 3 || queue[0] >= queue[2]);  // !ENQ_ENA
+  //
+  //   logic viol;                                                      // ENQ_ENA
+  //   always_comb begin : heap_invariant_detector
+  //     viol = 1'b0;
+  //     for (int i = 0; i < NODES_NEEDED; i++) begin
+  //       if (2*i+1 < NODES_NEEDED && queue[i] < queue[2*i+1]) viol = 1'b1;
+  //       if (2*i+2 < NODES_NEEDED && queue[i] < queue[2*i+2]) viol = 1'b1;
+  //     end
+  //   end
+  //   assign head_valid = !viol;
+
+  // Accepting a command mid-settle would discard the pending heapify (swap_result
+  // is applied only in the default branch), so absorb requires the same quiescence.
+  assign can_accept = head_valid;
 
 endmodule

--- a/hwpq/register_tree/rtl/src/register_tree.sv
+++ b/hwpq/register_tree/rtl/src/register_tree.sv
@@ -1,5 +1,27 @@
 `default_nettype none
 
+/*******************************************************************************
+  Module Name: register_tree
+  Date: 2026/06/22
+  Description: A register-based priority queue that preserves the heap
+               property across a binary tree of registers, closely
+               resembling a software heap. Enqueue searches for the leftmost
+               invalid entry and reorders the tree; dequeue and replace
+               remove/update the root in a single cycle while alternating-
+               level compare-and-swap operations restore heap order.
+  Parameters: ENQ_ENA - Enables the enqueue datapath when set
+              QUEUE_SIZE - Maximum number of elements in the priority queue
+              DATA_WIDTH - Bit width of data elements
+  Inputs: i_CLK - System clock
+          i_RSTn - Active-low reset signal
+          i_wrt - Write/insert command (enqueue/replace operation)
+          i_read - Read/pop command (dequeue/replace operation)
+          i_data - Input data to be enqueued (or used for replace)
+  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
+           o_empty - High when the queue is empty
+           o_data - Output data from the highest priority element
+*******************************************************************************/
+
 module register_tree #(
     parameter bit ENQ_ENA = 1,    // Define if user would like to enable enqueue
     parameter int QUEUE_SIZE = 4095,

--- a/hwpq/register_tree_pipelined/rtl/sim/register_tree_pipelined_tb.sv
+++ b/hwpq/register_tree_pipelined/rtl/sim/register_tree_pipelined_tb.sv
@@ -116,6 +116,21 @@ module register_tree_pipelined_tb;
 
   // Clock generation: 10ns period
   always #5 i_CLK <= ~i_CLK;
+  logic settled;
+  assign settled = o_write_ready || o_read_ready;
+  localparam int SETTLE_TIMEOUT = 10000;
+  task automatic poll_settled();
+    int guard;
+    guard = 0;
+    while (!settled) begin
+      @(negedge i_CLK);
+      guard++;
+      if (guard > SETTLE_TIMEOUT) begin
+        $fatal(1, "poll_settled: DUT never settled after %0d cycles (o_write_ready=%0b o_read_ready=%0b)",
+               SETTLE_TIMEOUT, o_write_ready, o_read_ready);
+      end
+    end
+  endtask
 
   int error_count = 0;
 
@@ -138,6 +153,7 @@ module register_tree_pipelined_tb;
     @(posedge i_CLK);
     i_RSTn = 1;
     @(posedge i_CLK);
+    @(negedge i_CLK);
 
     // Test with ENQ_ENA enabled
     $display("\n=== Testing with ENQ_ENA enabled ===");
@@ -241,6 +257,7 @@ module register_tree_pipelined_tb;
     @(posedge i_CLK);
     i_RSTn = 1;
     @(posedge i_CLK);
+    @(negedge i_CLK);
 
     // Initialize queue inside enqueue disabled module
     $display("\nInitializing enqueue disabled module by replacing into it");
@@ -252,7 +269,7 @@ module register_tree_pipelined_tb;
     end
     rsort_dis();
 
-    repeat (4) @(posedge i_CLK);
+    poll_settled();
 
     // Test Case 4: Dequeue Test with ENQ_ENA disabled
     $display("\nTest Case 4: Dequeue Test (ENQ_ENA disabled)");
@@ -356,6 +373,7 @@ module register_tree_pipelined_tb;
 
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     begin
+      poll_settled();
       if (o_write_ready) begin
         case (current_mode)
           ENABLED: begin
@@ -381,27 +399,19 @@ module register_tree_pipelined_tb;
       end else begin
         $display("Enqueue: Queue full, skipping enqueue");
       end
-      @(posedge i_CLK);
+      @(posedge i_CLK);  
+      @(negedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      case (current_mode)
-        ENABLED: begin
-          repeat ($clog2(QUEUE_SIZE)) @(posedge i_CLK);
-        end
-        DISABLED: begin
-          repeat (2) @(posedge i_CLK); // should have no effects
-        end
-        default: begin
-          $display("Enqueue: Invalid mode, skipping enqueue");
-        end
-      endcase
+      poll_settled();
     end
   endtask
 
   task automatic dequeue();
     begin
+      poll_settled();  // the DUT refuses commands while settling
       if (o_read_ready) begin
         case (current_mode)
           ENABLED: begin
@@ -433,18 +443,20 @@ module register_tree_pipelined_tb;
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
-      @(posedge i_CLK);
+      @(posedge i_CLK); 
+      @(negedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
 
-      repeat (2) @(posedge i_CLK);
+      poll_settled();
     end
   endtask
 
   task automatic replace(input logic [DATA_WIDTH-1:0] value);
     begin
+      poll_settled(); 
       case (current_mode)
         ENABLED: begin
           i_wrt_ena  = 1;
@@ -478,17 +490,19 @@ module register_tree_pipelined_tb;
         end
       endcase
       @(posedge i_CLK);
+      @(negedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
 
-      repeat (2) @(posedge i_CLK);
+      poll_settled();
     end
   endtask
 
   task automatic replace_init(input logic [DATA_WIDTH-1:0] value);
     begin
+      poll_settled();
       case (current_mode)
         ENABLED: begin
           i_wrt_ena  = 1;
@@ -505,12 +519,13 @@ module register_tree_pipelined_tb;
         end
       endcase
       @(posedge i_CLK);
+      @(negedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
 
-      repeat (2) @(posedge i_CLK);
+      poll_settled();
     end
   endtask
 

--- a/hwpq/register_tree_pipelined/rtl/sim/register_tree_pipelined_tb.sv
+++ b/hwpq/register_tree_pipelined/rtl/sim/register_tree_pipelined_tb.sv
@@ -117,6 +117,8 @@ module register_tree_pipelined_tb;
   // Clock generation: 10ns period
   always #5 CLK <= ~CLK;
 
+  int error_count = 0;
+
   initial begin
     // Initialize signals
     CLK = 0;
@@ -147,7 +149,7 @@ module register_tree_pipelined_tb;
       enqueue(random_value);
     end
     assert (o_full)
-    else $error("The queue should be filled by the intialization!");
+    else begin error_count++; $error("The queue should be filled by the intialization!"); end;
 
     // Test Case 1: Dequeue nodes with ENQ_ENA enabled
     $display("\nTest Case 1: Dequeue Test (ENQ_ENA enabled)");
@@ -156,10 +158,10 @@ module register_tree_pipelined_tb;
       if (!o_empty) begin
         assert (o_data == ref_queue_enq_1[0])
         else
-          $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+          begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
       end else begin
         assert (o_data == '0)
-        else $error("Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+        else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -170,10 +172,10 @@ module register_tree_pipelined_tb;
       enqueue(random_value);
       assert (o_data == ref_queue_enq_1[0])
       else
-        $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+        begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
     assert (o_full)
-    else $error("The queue should be filled after enqueue!");
+    else begin error_count++; $error("The queue should be filled after enqueue!"); end;
 
     // Test Case 3: Replace nodes with ENQ_ENA enabled
     $display("\nTest Case 3: Replace Test (ENQ_ENA enabled)");
@@ -182,7 +184,7 @@ module register_tree_pipelined_tb;
       replace(random_value);
       assert (o_data == ref_queue_enq_1[0])
       else
-        $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data);
+        begin error_count++; $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
 
     // Test case 4: Random opertaion for 50 times
@@ -195,25 +197,25 @@ module register_tree_pipelined_tb;
           enqueue(random_value);
           assert (o_data == ref_queue_enq_1[0])
           else
-            $error(
+            begin error_count++; $error(
                 "Random Enqueue: Node value mismatch -> expected %d, got %d",
                 ref_queue_enq_1[0],
                 o_data
-            );
+            ); end;
         end
         DEQUEUE: begin
           dequeue();
           if (!o_empty) begin
             assert (o_data == ref_queue_enq_1[0])
             else
-              $error(
+              begin error_count++; $error(
                   "Random Dequeue: Node value mismatch -> expected %d, got %d",
                   ref_queue_enq_1[0],
                   o_data
-              );
+              ); end;
           end else begin
             assert (o_data == '0)
-            else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+            else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
         REPLACE: begin
@@ -221,11 +223,11 @@ module register_tree_pipelined_tb;
           replace(random_value);
           assert (o_data == ref_queue_enq_1[0])
           else
-            $error(
+            begin error_count++; $error(
                 "Random Replace: Node value mismatch -> expected %d, got %d",
                 ref_queue_enq_1[0],
                 o_data
-            );
+            ); end;
         end
       endcase
     end
@@ -255,16 +257,16 @@ module register_tree_pipelined_tb;
     // Test Case 4: Dequeue Test with ENQ_ENA disabled
     $display("\nTest Case 4: Dequeue Test (ENQ_ENA disabled)");
     assert (o_full)
-    else $error("The queue should be filled by the intialization!");
+    else begin error_count++; $error("The queue should be filled by the intialization!"); end;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue_enq_0[0])
         else
-          $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+          begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
       end else begin
         assert (o_data == 'd0)
-        else $error("Dequeue: Node value mismatch -> expected %d, got %d", 'd0, o_data);
+        else begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", 'd0, o_data); end;
       end
     end
 
@@ -277,9 +279,9 @@ module register_tree_pipelined_tb;
       enqueue(random_value);
       assert (o_data == ref_queue_enq_0[0])
       else
-        $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+        begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
     end
-    assert (o_data == o_data_prev) else $error("The queue should not have change!");
+    assert (o_data == o_data_prev) else begin error_count++; $error("The queue should not have change!"); end;
     begin
       bit queues_match;
       bit error_flag;
@@ -295,9 +297,9 @@ module register_tree_pipelined_tb;
           end
         end
       end
-      assert (!error_flag) else $error("The queue should not have change!");
+      assert (!error_flag) else begin error_count++; $error("The queue should not have change!"); end;
     end
-    assert (!o_full && !o_empty) else $error("The queue should not do anything!");
+    assert (!o_full && !o_empty) else begin error_count++; $error("The queue should not do anything!"); end;
 
     // Test Case 6: Test Replace operation with ENQ_ENA disabled
     $display("\nTest Case 6: Replace Test (ENQ_ENA disabled)");
@@ -306,7 +308,7 @@ module register_tree_pipelined_tb;
       replace(random_value);
       assert (o_data == ref_queue_enq_0[0])
       else
-        $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data);
+        begin error_count++; $error("Replace: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
     end
 
     // Test case 8: Random opertaion for 50 times
@@ -319,14 +321,14 @@ module register_tree_pipelined_tb;
           if (!o_empty) begin
             assert (o_data == ref_queue_enq_0[0])
             else
-              $error(
+              begin error_count++; $error(
                   "Random Dequeue: Node value mismatch -> expected %d, got %d",
                   ref_queue_enq_0[0],
                   o_data
-              );
+              ); end;
           end else begin
             assert (o_data == '0)
-            else $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data);
+            else begin error_count++; $error("Random Dequeue: Node value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
         REPLACE: begin
@@ -334,17 +336,22 @@ module register_tree_pipelined_tb;
           replace(random_value);
           assert (o_data == ref_queue_enq_0[0])
           else
-            $error(
+            begin error_count++; $error(
                 "Random Replace: Node value mismatch -> expected %d, got %d",
                 ref_queue_enq_0[0],
                 o_data
-            );
+            ); end;
         end
       endcase
     end
 
-    $display("\nTest completed!");
-    $finish;
+    if (error_count == 0) begin
+      $display("\nTest completed!");
+      $finish;
+    end else begin
+      $display("\n%0d error(s) detected during simulation.", error_count);
+      $fatal(1, "Test FAILED with %0d error(s).", error_count);
+    end
   end
 
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);

--- a/hwpq/register_tree_pipelined/rtl/sim/register_tree_pipelined_tb.sv
+++ b/hwpq/register_tree_pipelined/rtl/sim/register_tree_pipelined_tb.sv
@@ -6,8 +6,8 @@ module register_tree_pipelined_tb;
   localparam int DATA_WIDTH = 16;
 
   // Clock and reset signals
-  logic                  CLK;
-  logic                  RSTn;
+  logic                  i_CLK;
+  logic                  i_RSTn;
 
   // Input signals - for ENQ_ENA enabled
   logic                  i_wrt_ena;
@@ -68,8 +68,8 @@ module register_tree_pipelined_tb;
       .QUEUE_SIZE(QUEUE_SIZE),
       .DATA_WIDTH(DATA_WIDTH)
   ) u_RegisterTree_ena (
-      .i_CLK  (CLK),
-      .i_RSTn (RSTn),
+      .i_CLK  (i_CLK),
+      .i_RSTn (i_RSTn),
       .i_wrt  (i_wrt_ena),
       .i_read (i_read_ena),
       .i_data (i_data_ena),
@@ -84,8 +84,8 @@ module register_tree_pipelined_tb;
       .QUEUE_SIZE(QUEUE_SIZE),
       .DATA_WIDTH(DATA_WIDTH)
   ) u_RegisterTree_dis (
-      .i_CLK  (CLK),
-      .i_RSTn (RSTn),
+      .i_CLK  (i_CLK),
+      .i_RSTn (i_RSTn),
       .i_wrt  (i_wrt_dis),
       .i_read (i_read_dis),
       .i_data (i_data_dis),
@@ -115,13 +115,13 @@ module register_tree_pipelined_tb;
   end
 
   // Clock generation: 10ns period
-  always #5 CLK <= ~CLK;
+  always #5 i_CLK <= ~i_CLK;
 
   int error_count = 0;
 
   initial begin
     // Initialize signals
-    CLK = 0;
+    i_CLK = 0;
     i_wrt_ena = 0;
     i_read_ena = 0;
     i_data_ena = 0;
@@ -134,10 +134,10 @@ module register_tree_pipelined_tb;
     ref_queue_prev = {};
 
     // Reset the modules
-    RSTn = 0;
-    @(posedge CLK);
-    RSTn = 1;
-    @(posedge CLK);
+    i_RSTn = 0;
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    @(posedge i_CLK);
 
     // Test with ENQ_ENA enabled
     $display("\n=== Testing with ENQ_ENA enabled ===");
@@ -237,10 +237,10 @@ module register_tree_pipelined_tb;
     current_mode = DISABLED;
 
     // Reset the modules
-    RSTn = 0;
-    @(posedge CLK);
-    RSTn = 1;
-    @(posedge CLK);
+    i_RSTn = 0;
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    @(posedge i_CLK);
 
     // Initialize queue inside enqueue disabled module
     $display("\nInitializing enqueue disabled module by replacing into it");
@@ -252,7 +252,7 @@ module register_tree_pipelined_tb;
     end
     rsort_dis();
 
-    repeat (4) @(posedge CLK);
+    repeat (4) @(posedge i_CLK);
 
     // Test Case 4: Dequeue Test with ENQ_ENA disabled
     $display("\nTest Case 4: Dequeue Test (ENQ_ENA disabled)");
@@ -381,17 +381,17 @@ module register_tree_pipelined_tb;
       end else begin
         $display("Enqueue: Queue full, skipping enqueue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
       case (current_mode)
         ENABLED: begin
-          repeat ($clog2(QUEUE_SIZE)) @(posedge CLK);
+          repeat ($clog2(QUEUE_SIZE)) @(posedge i_CLK);
         end
         DISABLED: begin
-          repeat (2) @(posedge CLK); // should have no effects
+          repeat (2) @(posedge i_CLK); // should have no effects
         end
         default: begin
           $display("Enqueue: Invalid mode, skipping enqueue");
@@ -433,13 +433,13 @@ module register_tree_pipelined_tb;
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
 
-      repeat (2) @(posedge CLK);
+      repeat (2) @(posedge i_CLK);
     end
   endtask
 
@@ -477,13 +477,13 @@ module register_tree_pipelined_tb;
           $display("Replace: Invalid mode, skipping replace");
         end
       endcase
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
 
-      repeat (2) @(posedge CLK);
+      repeat (2) @(posedge i_CLK);
     end
   endtask
 
@@ -504,13 +504,13 @@ module register_tree_pipelined_tb;
           $display("Replace: Invalid mode, skipping replace");
         end
       endcase
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
 
-      repeat (2) @(posedge CLK);
+      repeat (2) @(posedge i_CLK);
     end
   endtask
 

--- a/hwpq/register_tree_pipelined/rtl/sim/register_tree_pipelined_tb.sv
+++ b/hwpq/register_tree_pipelined/rtl/sim/register_tree_pipelined_tb.sv
@@ -419,8 +419,8 @@ module register_tree_pipelined_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+
+      repeat (2) @(posedge CLK);
     end
   endtask
 
@@ -457,8 +457,8 @@ module register_tree_pipelined_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+
+      repeat (2) @(posedge CLK);
     end
   endtask
 
@@ -478,8 +478,8 @@ module register_tree_pipelined_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat (2) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK);
+
+      repeat (2) @(posedge CLK);
     end
   endtask
 

--- a/hwpq/register_tree_pipelined/rtl/sim/register_tree_pipelined_tb.sv
+++ b/hwpq/register_tree_pipelined/rtl/sim/register_tree_pipelined_tb.sv
@@ -20,18 +20,18 @@ module register_tree_pipelined_tb;
   logic [DATA_WIDTH-1:0] i_data_dis;
 
   // Output signals - for ENQ_ENA enabled
-  logic                  o_full_ena;
-  logic                  o_empty_ena;
+  logic                  o_write_ready_ena;
+  logic                  o_read_ready_ena;
   logic [DATA_WIDTH-1:0] o_data_ena;
 
   // Output signals - for ENQ_ENA disabled
-  logic                  o_full_dis;
-  logic                  o_empty_dis;
+  logic                  o_write_ready_dis;
+  logic                  o_read_ready_dis;
   logic [DATA_WIDTH-1:0] o_data_dis;
 
   // Current active outputs for testing
-  logic                  o_full;
-  logic                  o_empty;
+  logic                  o_write_ready;
+  logic                  o_read_ready;
   logic [DATA_WIDTH-1:0] o_data;
   logic [DATA_WIDTH-1:0] o_data_prev;
 
@@ -73,8 +73,8 @@ module register_tree_pipelined_tb;
       .i_wrt  (i_wrt_ena),
       .i_read (i_read_ena),
       .i_data (i_data_ena),
-      .o_full (o_full_ena),
-      .o_empty(o_empty_ena),
+      .o_write_ready (o_write_ready_ena),
+      .o_read_ready(o_read_ready_ena),
       .o_data (o_data_ena)
   );
 
@@ -89,26 +89,26 @@ module register_tree_pipelined_tb;
       .i_wrt  (i_wrt_dis),
       .i_read (i_read_dis),
       .i_data (i_data_dis),
-      .o_full (o_full_dis),
-      .o_empty(o_empty_dis),
+      .o_write_ready (o_write_ready_dis),
+      .o_read_ready(o_read_ready_dis),
       .o_data (o_data_dis)
   );
 
   always_comb begin : output_signal_switch
     case (current_mode)
       ENABLED: begin
-        o_full  = o_full_ena;
-        o_empty = o_empty_ena;
+        o_write_ready  = o_write_ready_ena;
+        o_read_ready = o_read_ready_ena;
         o_data  = o_data_ena;
       end
       DISABLED: begin
-        o_full  = o_full_dis;
-        o_empty = o_empty_dis;
+        o_write_ready  = o_write_ready_dis;
+        o_read_ready = o_read_ready_dis;
         o_data  = o_data_dis;
       end
       default: begin
-        o_full  = o_full_dis;
-        o_empty = o_empty_dis;
+        o_write_ready  = o_write_ready_dis;
+        o_read_ready = o_read_ready_dis;
         o_data  = o_data_dis;
       end
     endcase
@@ -148,14 +148,14 @@ module register_tree_pipelined_tb;
       random_value = $urandom_range(1, 1023);
       enqueue(random_value);
     end
-    assert (o_full)
+    assert (!o_write_ready)
     else begin error_count++; $error("The queue should be filled by the intialization!"); end;
 
     // Test Case 1: Dequeue nodes with ENQ_ENA enabled
     $display("\nTest Case 1: Dequeue Test (ENQ_ENA enabled)");
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue_enq_1[0])
         else
           begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
@@ -174,7 +174,7 @@ module register_tree_pipelined_tb;
       else
         begin error_count++; $error("Enqueue: Node value mismatch -> expected %d, got %d", ref_queue_enq_1[0], o_data); end;
     end
-    assert (o_full)
+    assert (!o_write_ready)
     else begin error_count++; $error("The queue should be filled after enqueue!"); end;
 
     // Test Case 3: Replace nodes with ENQ_ENA enabled
@@ -205,7 +205,7 @@ module register_tree_pipelined_tb;
         end
         DEQUEUE: begin
           dequeue();
-          if (!o_empty) begin
+          if (o_read_ready) begin
             assert (o_data == ref_queue_enq_1[0])
             else
               begin error_count++; $error(
@@ -256,11 +256,11 @@ module register_tree_pipelined_tb;
 
     // Test Case 4: Dequeue Test with ENQ_ENA disabled
     $display("\nTest Case 4: Dequeue Test (ENQ_ENA disabled)");
-    assert (o_full)
+    assert (!o_write_ready)
     else begin error_count++; $error("The queue should be filled by the intialization!"); end;
     for (int i = 0; i < QUEUE_SIZE / 2; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue_enq_0[0])
         else
           begin error_count++; $error("Dequeue: Node value mismatch -> expected %d, got %d", ref_queue_enq_0[0], o_data); end;
@@ -299,7 +299,7 @@ module register_tree_pipelined_tb;
       end
       assert (!error_flag) else begin error_count++; $error("The queue should not have change!"); end;
     end
-    assert (!o_full && !o_empty) else begin error_count++; $error("The queue should not do anything!"); end;
+    assert (o_write_ready && o_read_ready) else begin error_count++; $error("The queue should not do anything!"); end;
 
     // Test Case 6: Test Replace operation with ENQ_ENA disabled
     $display("\nTest Case 6: Replace Test (ENQ_ENA disabled)");
@@ -318,7 +318,7 @@ module register_tree_pipelined_tb;
       case (random_operation)
         DEQUEUE: begin
           dequeue();
-          if (!o_empty) begin
+          if (o_read_ready) begin
             assert (o_data == ref_queue_enq_0[0])
             else
               begin error_count++; $error(
@@ -356,7 +356,7 @@ module register_tree_pipelined_tb;
 
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (!o_full) begin
+      if (o_write_ready) begin
         case (current_mode)
           ENABLED: begin
             i_wrt_ena = 1;
@@ -402,7 +402,7 @@ module register_tree_pipelined_tb;
 
   task automatic dequeue();
     begin
-      if (!o_empty) begin
+      if (o_read_ready) begin
         case (current_mode)
           ENABLED: begin
             i_wrt_ena  = 0;
@@ -450,7 +450,7 @@ module register_tree_pipelined_tb;
           i_wrt_ena  = 1;
           i_read_ena = 1;
           i_data_ena = value;
-          if (o_empty) begin
+          if (!o_read_ready) begin
             ref_queue_enq_1[ref_queue_enq_1_size] = value;
             ref_queue_enq_1_size++;
 
@@ -464,7 +464,7 @@ module register_tree_pipelined_tb;
           i_wrt_dis  = 1;
           i_read_dis = 1;
           i_data_dis = value;
-          if (o_empty) begin
+          if (!o_read_ready) begin
             ref_queue_enq_0[ref_queue_enq_0_size] = value;
             ref_queue_enq_0_size++;
             rsort_dis();

--- a/hwpq/register_tree_pipelined/rtl/sim/register_tree_pipelined_tb.sv
+++ b/hwpq/register_tree_pipelined/rtl/sim/register_tree_pipelined_tb.sv
@@ -357,21 +357,27 @@ module register_tree_pipelined_tb;
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     begin
       if (!o_full) begin
-        if (current_mode == ENABLED) begin
-          i_wrt_ena = 1;
-          i_read_ena = 0;
-          i_data_ena = value;
+        case (current_mode)
+          ENABLED: begin
+            i_wrt_ena = 1;
+            i_read_ena = 0;
+            i_data_ena = value;
 
-          ref_queue_enq_1[ref_queue_enq_1_size] = value;
-          ref_queue_enq_1_size++;
-      
-          rsort_ena();
-        end else if (current_mode == DISABLED) begin
-          i_wrt_dis = 1;
-          i_read_dis = 0;
-          i_data_dis = value;
-//          $display("Enqueue attempt with ENQ_ENA disabled - should have no effect");
-        end
+            ref_queue_enq_1[ref_queue_enq_1_size] = value;
+            ref_queue_enq_1_size++;
+
+            rsort_ena();
+          end
+          DISABLED: begin
+            i_wrt_dis = 1;
+            i_read_dis = 0;
+            i_data_dis = value;
+//            $display("Enqueue attempt with ENQ_ENA disabled - should have no effect");
+          end
+          default: begin
+            $display("Enqueue: Invalid mode, skipping enqueue");
+          end
+        endcase
       end else begin
         $display("Enqueue: Queue full, skipping enqueue");
       end
@@ -380,37 +386,50 @@ module register_tree_pipelined_tb;
       i_read_ena = 0;
       i_wrt_dis  = 0;
       i_read_dis = 0;
-      if (current_mode == ENABLED) repeat ($clog2(QUEUE_SIZE)) @(posedge CLK);
-      else if (current_mode == DISABLED) repeat (2) @(posedge CLK); // should have no effects
+      case (current_mode)
+        ENABLED: begin
+          repeat ($clog2(QUEUE_SIZE)) @(posedge CLK);
+        end
+        DISABLED: begin
+          repeat (2) @(posedge CLK); // should have no effects
+        end
+        default: begin
+          $display("Enqueue: Invalid mode, skipping enqueue");
+        end
+      endcase
     end
   endtask
 
   task automatic dequeue();
     begin
       if (!o_empty) begin
-        if (current_mode == ENABLED) begin
-          i_wrt_ena  = 0;
-          i_read_ena = 1;
-          i_data_ena = 0;
+        case (current_mode)
+          ENABLED: begin
+            i_wrt_ena  = 0;
+            i_read_ena = 1;
+            i_data_ena = 0;
 
-          for (int i = 0; i < ref_queue_enq_1_size - 1; i++) begin
-            ref_queue_enq_1[i] = ref_queue_enq_1[i+1];
+            for (int i = 0; i < ref_queue_enq_1_size - 1; i++) begin
+              ref_queue_enq_1[i] = ref_queue_enq_1[i+1];
+            end
+            ref_queue_enq_1[ref_queue_enq_1_size-1] = '0;
+            ref_queue_enq_1_size--;
           end
-          ref_queue_enq_1[ref_queue_enq_1_size-1] = '0; 
-          ref_queue_enq_1_size--;
+          DISABLED: begin
+            i_wrt_dis  = 0;
+            i_read_dis = 1;
+            i_data_dis = 0;
 
-        end else if (current_mode == DISABLED) begin
-          i_wrt_dis  = 0;
-          i_read_dis = 1;
-          i_data_dis = 0;
-
-          for (int i = 0; i < ref_queue_enq_0_size - 1; i++) begin
-            ref_queue_enq_0[i] = ref_queue_enq_0[i+1];
+            for (int i = 0; i < ref_queue_enq_0_size - 1; i++) begin
+              ref_queue_enq_0[i] = ref_queue_enq_0[i+1];
+            end
+            ref_queue_enq_0[ref_queue_enq_0_size-1] = '0;
+            ref_queue_enq_0_size--;
           end
-          ref_queue_enq_0[ref_queue_enq_0_size-1] = '0; 
-          ref_queue_enq_0_size--;
-
-        end
+          default: begin
+            $display("Dequeue: Invalid mode, skipping dequeue");
+          end
+        endcase
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
@@ -426,32 +445,38 @@ module register_tree_pipelined_tb;
 
   task automatic replace(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (current_mode == ENABLED) begin
-        i_wrt_ena  = 1;
-        i_read_ena = 1;
-        i_data_ena = value;
-        if (o_empty) begin
-          ref_queue_enq_1[ref_queue_enq_1_size] = value;
-          ref_queue_enq_1_size++;
-          
-          rsort_ena();
-        end else begin
-          ref_queue_enq_1[0] = value;
-          rsort_ena();
+      case (current_mode)
+        ENABLED: begin
+          i_wrt_ena  = 1;
+          i_read_ena = 1;
+          i_data_ena = value;
+          if (o_empty) begin
+            ref_queue_enq_1[ref_queue_enq_1_size] = value;
+            ref_queue_enq_1_size++;
+
+            rsort_ena();
+          end else begin
+            ref_queue_enq_1[0] = value;
+            rsort_ena();
+          end
         end
-      end else if (current_mode == DISABLED) begin
-        i_wrt_dis  = 1;
-        i_read_dis = 1;
-        i_data_dis = value;
-        if (o_empty) begin
-          ref_queue_enq_0[ref_queue_enq_0_size] = value;
-          ref_queue_enq_0_size++;
-          rsort_dis();
-        end else begin
-          ref_queue_enq_0[0] = value;
-          rsort_dis();
+        DISABLED: begin
+          i_wrt_dis  = 1;
+          i_read_dis = 1;
+          i_data_dis = value;
+          if (o_empty) begin
+            ref_queue_enq_0[ref_queue_enq_0_size] = value;
+            ref_queue_enq_0_size++;
+            rsort_dis();
+          end else begin
+            ref_queue_enq_0[0] = value;
+            rsort_dis();
+          end
         end
-      end
+        default: begin
+          $display("Replace: Invalid mode, skipping replace");
+        end
+      endcase
       @(posedge CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;
@@ -464,15 +489,21 @@ module register_tree_pipelined_tb;
 
   task automatic replace_init(input logic [DATA_WIDTH-1:0] value);
     begin
-      if (current_mode == ENABLED) begin
-        i_wrt_ena  = 1;
-        i_read_ena = 1;
-        i_data_ena = value;
-      end else if (current_mode == DISABLED) begin
-        i_wrt_dis  = 1;
-        i_read_dis = 1;
-        i_data_dis = value;
-      end
+      case (current_mode)
+        ENABLED: begin
+          i_wrt_ena  = 1;
+          i_read_ena = 1;
+          i_data_ena = value;
+        end
+        DISABLED: begin
+          i_wrt_dis  = 1;
+          i_read_dis = 1;
+          i_data_dis = value;
+        end
+        default: begin
+          $display("Replace: Invalid mode, skipping replace");
+        end
+      endcase
       @(posedge CLK);
       i_wrt_ena  = 0;
       i_read_ena = 0;

--- a/hwpq/register_tree_pipelined/rtl/src/register_tree_pipelined.sv
+++ b/hwpq/register_tree_pipelined/rtl/src/register_tree_pipelined.sv
@@ -1,5 +1,25 @@
 `default_nettype none
 
+/*******************************************************************************
+  Module Name: register_tree_pipelined
+  Date: 2026/06/21
+  Description: A pipelined version of the register tree architecture that
+               divides the compare-and-swap logic between clock cycles to
+               reduce combinational path length, at the cost of enqueue
+               taking two cycles to propagate a new entry into place.
+  Parameters: ENQ_ENA - Enables the enqueue datapath when set
+              QUEUE_SIZE - Maximum number of elements in the priority queue
+              DATA_WIDTH - Bit width of data elements
+  Inputs: i_CLK - System clock
+          i_RSTn - Active-low reset signal
+          i_wrt - Write/insert command (enqueue/replace operation)
+          i_read - Read/pop command (dequeue/replace operation)
+          i_data - Input data to be enqueued (or used for replace)
+  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
+           o_empty - High when the queue is empty
+           o_data - Output data from the highest priority element
+*******************************************************************************/
+
 module register_tree_pipelined #(
     parameter bit ENQ_ENA = 1,
     parameter int QUEUE_SIZE = 15,

--- a/hwpq/register_tree_pipelined/rtl/src/register_tree_pipelined.sv
+++ b/hwpq/register_tree_pipelined/rtl/src/register_tree_pipelined.sv
@@ -43,6 +43,10 @@ module register_tree_pipelined #(
   //----------------------------------------------------------------------
   localparam int TREE_DEPTH = $clog2(QUEUE_SIZE);  // depth of the tree
   localparam int NODES_NEEDED = (1 << TREE_DEPTH) - 1;  // number of nodes needed to initialize
+  // Worst-case settle cycles. One level sifted per cycle => uniform bound for
+  // every op (climb or sink): TREE_DEPTH-1 transitions + a parity-slack cycle.
+  localparam int SETTLE_CYCLES = TREE_DEPTH;
+  localparam int CNT_W         = $clog2(SETTLE_CYCLES + 1);
 
   //----------------------------------------------------------------------
   // Internal Registers and Wires
@@ -57,7 +61,11 @@ module register_tree_pipelined #(
   logic [$clog2(NODES_NEEDED)-1:0] next_size;
 
   logic empty, full, enqueue, dequeue, replace;
+  logic next_empty, next_full;
   logic even_cycle_flag, next_even_cycle_flag;
+  logic head_valid, can_accept;
+
+  logic [CNT_W-1:0] settle_cnt, next_settle_cnt;
 
   int found_empty_index;
 
@@ -78,14 +86,19 @@ module register_tree_pipelined #(
   // Signals assignments
   //----------------------------------------------------------------------
 
-  assign enqueue = (ENQ_ENA && i_wrt && !i_read) ? 1'b1 : 1'b0; // Only enable enqueue if ENQ_ENA is high
-  assign dequeue = !i_wrt && i_read ? 1'b1 : 1'b0;
-  assign replace = i_wrt && i_read ? 1'b1 : 1'b0;
+  // A command is refused unless the queue can honor it (this also gates size).
+  // Enqueue/dequeue gate on full/empty; replace pops-and-pushes so needs neither.
+  assign enqueue = (ENQ_ENA && i_wrt && !i_read) ? o_write_ready : 1'b0;
+  assign dequeue = (!i_wrt && i_read) ? o_read_ready : 1'b0;
+  assign replace = (i_wrt && i_read) ? (can_accept && head_valid) : 1'b0;
 
-  assign empty = (size <= 0) ? 1'b1 : 1'b0;
-  assign full = (size >= QUEUE_SIZE) ? 1'b1 : 1'b0;
-  assign o_write_ready = !full;
-  assign o_read_ready = !empty;
+  // full/empty are REGISTERED (see update_registers): flopping the >=QUEUE_SIZE
+  // comparator keeps it off the decode path; value is identical every cycle.
+  assign next_empty = (next_size == 0) ? 1'b1 : 1'b0;
+  assign next_full  = (next_size >= QUEUE_SIZE) ? 1'b1 : 1'b0;
+
+  assign o_write_ready = !full && can_accept;
+  assign o_read_ready = !empty && head_valid;
   assign o_data = queue[0];
 
   //----------------------------------------------------------------------
@@ -237,13 +250,52 @@ module register_tree_pipelined #(
       end
       size            <= 0;
       even_cycle_flag <= 1'b1;
+      settle_cnt      <= '0;  // reset queue is settled
+      full            <= 1'b0;
+      empty           <= 1'b1;  // size resets to 0
     end else begin
       for (int i = 0; i < NODES_NEEDED; i++) begin
         queue[i] <= next_queue[i];
       end
       size            <= next_size;
       even_cycle_flag <= next_even_cycle_flag;
+      settle_cnt      <= next_settle_cnt;
+      full            <= next_full;
+      empty           <= next_empty;
     end
   end
+
+  // Settled detector: uniform settle countdown (see localparams). head_valid is
+  // a compare against a counter flop, not an O(N) heap scan, to keep it off the
+  // critical path (that cone failed by ~1ns when flopped)
+  always_comb begin : calculate_next_settle_cnt
+    if (enqueue || dequeue || replace) begin
+      next_settle_cnt = SETTLE_CYCLES[CNT_W-1:0];
+    end else if (settle_cnt != 0) begin
+      next_settle_cnt = settle_cnt - 1'b1;
+    end else begin
+      next_settle_cnt = '0;
+    end
+  end
+
+  assign head_valid = (settle_cnt == 0);
+
+  // Data-adaptive alternative (releases earlier, but puts an O(N) cone on the
+  // critical path). This module needs the FULL invariant even without enqueue:
+  // it sifts one level-pair/cycle, so root-local reports settled early.
+  
+  // this decreased FMax but ultimately increased throughput for some queue sizes
+  
+  //   always_comb begin : heap_invariant_detector
+  //     head_valid = 1'b1;
+  //     for (int i = 0; i < NODES_NEEDED; i++) begin
+  //       if (2*i+1 < NODES_NEEDED && queue[i] < queue[2*i+1]) head_valid = 1'b0;
+  //       if (2*i+2 < NODES_NEEDED && queue[i] < queue[2*i+2]) head_valid = 1'b0;
+  //     end
+  //   end
+
+  // Accepting a command mid-settle would discard the pending heapify (swap_result
+  // is applied only in the default branch), so absorb requires the same quiescence.
+  assign can_accept = head_valid;
 
 endmodule

--- a/hwpq/register_tree_pipelined/rtl/src/register_tree_pipelined.sv
+++ b/hwpq/register_tree_pipelined/rtl/src/register_tree_pipelined.sv
@@ -15,8 +15,8 @@
           i_wrt - Write/insert command (enqueue/replace operation)
           i_read - Read/pop command (dequeue/replace operation)
           i_data - Input data to be enqueued (or used for replace)
-  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
-           o_empty - High when the queue is empty
+  Outputs: o_write_ready - High when the queue has room to accept a write
+           o_read_ready - High when the queue holds data available to read
            o_data - Output data from the highest priority element
 *******************************************************************************/
 
@@ -33,8 +33,8 @@ module register_tree_pipelined #(
     input var logic i_read,
     input var logic [DATA_WIDTH-1:0] i_data,
     // Outputs
-    output var logic o_full,
-    output var logic o_empty,
+    output var logic o_write_ready,
+    output var logic o_read_ready,
     output var logic [DATA_WIDTH-1:0] o_data
 );
 
@@ -84,8 +84,8 @@ module register_tree_pipelined #(
 
   assign empty = (size <= 0) ? 1'b1 : 1'b0;
   assign full = (size >= QUEUE_SIZE) ? 1'b1 : 1'b0;
-  assign o_full = full;
-  assign o_empty = empty;
+  assign o_write_ready = !full;
+  assign o_read_ready = !empty;
   assign o_data = queue[0];
 
   //----------------------------------------------------------------------

--- a/hwpq/systolic_array/rtl/sim/systolic_array_bug_tb.sv
+++ b/hwpq/systolic_array/rtl/sim/systolic_array_bug_tb.sv
@@ -50,6 +50,8 @@ module systolic_array_tb;
   // Clock generation: 10ns period
   always #5 CLK <= ~CLK;
 
+  int error_count = 0;
+
   initial begin
     // Initialize signals
     CLK = 0;
@@ -103,10 +105,10 @@ module systolic_array_tb;
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue[0])
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
         assert (o_data == '0)
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -152,10 +154,10 @@ module systolic_array_tb;
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue[0])
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
         assert (o_data == '0)
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -200,10 +202,10 @@ module systolic_array_tb;
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue[0])
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
         assert (o_data == '0)
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -249,15 +251,20 @@ module systolic_array_tb;
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue[0])
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
         assert (o_data == '0)
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
-    $display("\nTest completed! ");
-    $finish;
+    if (error_count == 0) begin
+      $display("\nTest completed!");
+      $finish;
+    end else begin
+      $display("\n%0d error(s) detected during simulation.", error_count);
+      $fatal(1, "Test FAILED with %0d error(s).", error_count);
+    end
   end
 
   // Task to read root node

--- a/hwpq/systolic_array/rtl/sim/systolic_array_bug_tb.sv
+++ b/hwpq/systolic_array/rtl/sim/systolic_array_bug_tb.sv
@@ -4,8 +4,8 @@ module systolic_array_tb;
   parameter int DATA_WIDTH = 16;
 
   // Clock and reset signals
-  logic                  CLK;
-  logic                  RSTn;
+  logic                  i_CLK;
+  logic                  i_RSTn;
 
   // Input signals
   logic                  i_wrt;
@@ -37,8 +37,8 @@ module systolic_array_tb;
       .QUEUE_SIZE(QUEUE_SIZE),
       .DATA_WIDTH(DATA_WIDTH)
   ) u_SystolicArray (
-      .i_CLK(CLK),
-      .i_RSTn(RSTn),
+      .i_CLK(i_CLK),
+      .i_RSTn(i_RSTn),
       .i_wrt(i_wrt),
       .i_read(i_read),
       .i_data(i_data),
@@ -48,22 +48,22 @@ module systolic_array_tb;
   );
 
   // Clock generation: 10ns period
-  always #5 CLK <= ~CLK;
+  always #5 i_CLK <= ~i_CLK;
 
   int error_count = 0;
 
   initial begin
     // Initialize signals
-    CLK = 0;
-    RSTn = 0;
+    i_CLK = 0;
+    i_RSTn = 0;
     i_wrt = 0;
     i_read = 0;
     i_data = 0;
 
     // Reset the module
-    @(posedge CLK);
-    RSTn = 1;
-    @(posedge CLK);
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    @(posedge i_CLK);
 
     // Test Case 1: Successive decreasing numbers in IB
     $display("\nTest Case 1: Successive decreasing numbers in IB");
@@ -87,7 +87,7 @@ module systolic_array_tb;
     u_SystolicArray.size = 4'd8;
     u_SystolicArray.size_next = 4'd8;
 
-    @(posedge CLK);
+    @(posedge i_CLK);
 
     ref_queue.push_back(16'd1);
     ref_queue.push_back(16'd6);
@@ -107,7 +107,7 @@ module systolic_array_tb;
         end
       end
     end
-    repeat (10) @(posedge CLK);
+    repeat (10) @(posedge i_CLK);
 
     for (int i = 0; i < 8; i++) begin
       dequeue();
@@ -135,7 +135,7 @@ module systolic_array_tb;
     u_SystolicArray.size = 4'd8;
     u_SystolicArray.size_next = 4'd8;
 
-    @(posedge CLK);
+    @(posedge i_CLK);
 
     ref_queue.push_back(16'd1);
     ref_queue.push_back(16'd6);
@@ -156,7 +156,7 @@ module systolic_array_tb;
         end
       end
     end
-    repeat (10) @(posedge CLK);
+    repeat (10) @(posedge i_CLK);
 
     for (int i = 0; i < 8; i++) begin
       dequeue();
@@ -183,7 +183,7 @@ module systolic_array_tb;
     u_SystolicArray.size = 4'd8;
     u_SystolicArray.size_next = 4'd8;
 
-    @(posedge CLK);
+    @(posedge i_CLK);
 
     ref_queue.push_back(16'd1);
     ref_queue.push_back(16'd2);
@@ -204,7 +204,7 @@ module systolic_array_tb;
         end
       end
     end
-    repeat (10) @(posedge CLK);
+    repeat (10) @(posedge i_CLK);
 
     for (int i = 0; i < 8; i++) begin
       dequeue();
@@ -232,7 +232,7 @@ module systolic_array_tb;
     u_SystolicArray.size = 4'd8;
     u_SystolicArray.size_next = 4'd8;
 
-    @(posedge CLK);
+    @(posedge i_CLK);
 
     ref_queue.push_back(16'd1);
     ref_queue.push_back(16'd2);
@@ -253,7 +253,7 @@ module systolic_array_tb;
         end
       end
     end
-    repeat (10) @(posedge CLK);
+    repeat (10) @(posedge i_CLK);
 
     for (int i = 0; i < 8; i++) begin
       dequeue();
@@ -290,10 +290,10 @@ module systolic_array_tb;
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (3) @(posedge CLK);
+      repeat (3) @(posedge i_CLK);
     end
   endtask
 
@@ -319,10 +319,10 @@ module systolic_array_tb;
         $display("Replace: Queue empty, skipping replace");
       end
       
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (2) @(posedge CLK); 
+      repeat (2) @(posedge i_CLK); 
     end
   endtask
 

--- a/hwpq/systolic_array/rtl/sim/systolic_array_bug_tb.sv
+++ b/hwpq/systolic_array/rtl/sim/systolic_array_bug_tb.sv
@@ -22,16 +22,6 @@ module systolic_array_tb;
   int                    ref_size = 0;
   logic [DATA_WIDTH-1:0] tmp;
 
-  // Test variables
-  logic [DATA_WIDTH-1:0] random_value;
-
-  typedef enum int {
-    ENQUEUE = 1,
-    DEQUEUE = 2,
-    REPLACE = 3
-  } t_operation;
-  t_operation random_operation;
-
   // Instantiate the register_tree module
   systolic_array #(
       .QUEUE_SIZE(QUEUE_SIZE),
@@ -76,28 +66,26 @@ module systolic_array_tb;
       Forcing a single word fails too with "cannot force to the word of a variable array". 
       The same applies to the other test cases below. */
     
-    u_SystolicArray.IB[0] = 16'd1;
+    u_SystolicArray.IB[0] = 16'd0;
     u_SystolicArray.IB[1] = 16'd6;
     u_SystolicArray.IB[2] = 16'd4;
     u_SystolicArray.IB[3] = 16'd2;
     u_SystolicArray.OB[0] = 16'd12;
     u_SystolicArray.OB[1] = 16'd11;
     u_SystolicArray.OB[2] = 16'd10;
-    u_SystolicArray.OB[3] = 16'd9;
-    u_SystolicArray.size = 4'd8;
-    u_SystolicArray.size_next = 4'd8;
+    u_SystolicArray.OB[3] = 16'd0;
+    u_SystolicArray.size = 4'd6;
+    u_SystolicArray.size_next = 4'd6;
 
     @(posedge i_CLK);
 
-    ref_queue.push_back(16'd1);
     ref_queue.push_back(16'd6);
     ref_queue.push_back(16'd4);
     ref_queue.push_back(16'd2);
     ref_queue.push_back(16'd12);
     ref_queue.push_back(16'd11);
     ref_queue.push_back(16'd10);
-    ref_queue.push_back(16'd9);
-    ref_size = 8;
+    ref_size = 6;
     for (int i = 0; i < ref_size; i++) begin
       for (int j = i + 1; j < ref_size; j++) begin
         if (ref_queue[i] < ref_queue[j]) begin
@@ -109,92 +97,33 @@ module systolic_array_tb;
     end
     repeat (10) @(posedge i_CLK);
 
-    for (int i = 0; i < 8; i++) begin
+    for (int i = 0; i < QUEUE_SIZE; i++) begin
       dequeue();
-      if (o_read_ready) begin
-        assert (o_data == ref_queue[0])
-        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
-      end else begin
-        assert (o_data == '0)
-        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
-      end
     end
 
-    // Test Case 2: Successive decreasing numbers in IB
-    $display("\nTest Case 2: Successive increasing numbers in OB");
+    // Test Case 2: Successive decreasing numbers from IB to OB+1
+    $display("\nTest Case 2: Successive decreasing numbers from IB to OB+1");
     ref_queue.delete();
-
-    u_SystolicArray.IB[0] = 16'd1;
-    u_SystolicArray.IB[1] = 16'd2;
-    u_SystolicArray.IB[2] = 16'd4;
-    u_SystolicArray.IB[3] = 16'd6;
-    u_SystolicArray.OB[0] = 16'd12;
-    u_SystolicArray.OB[1] = 16'd9;
-    u_SystolicArray.OB[2] = 16'd10;
-    u_SystolicArray.OB[3] = 16'd11;
-    u_SystolicArray.size = 4'd8;
-    u_SystolicArray.size_next = 4'd8;
-
-    @(posedge i_CLK);
-
-    ref_queue.push_back(16'd1);
-    ref_queue.push_back(16'd6);
-    ref_queue.push_back(16'd4);
-    ref_queue.push_back(16'd2);
-    ref_queue.push_back(16'd12);
-    ref_queue.push_back(16'd11);
-    ref_queue.push_back(16'd10);
-    ref_queue.push_back(16'd9);
-
-    ref_size = 8;
-    for (int i = 0; i < ref_size; i++) begin
-      for (int j = i + 1; j < ref_size; j++) begin
-        if (ref_queue[i] < ref_queue[j]) begin
-          tmp = ref_queue[i];
-          ref_queue[i] = ref_queue[j];
-          ref_queue[j] = tmp;
-        end
-      end
-    end
-    repeat (10) @(posedge i_CLK);
-
-    for (int i = 0; i < 8; i++) begin
-      dequeue();
-      if (o_read_ready) begin
-        assert (o_data == ref_queue[0])
-        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
-      end else begin
-        assert (o_data == '0)
-        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
-      end
-    end
-
-    // Test Case 3: Successive decreasing numbers from IB to OB+1
-    $display("\nTest Case 3: Successive decreasing numbers from IB to OB+1");
-    ref_queue.delete();
-    u_SystolicArray.IB[0] = 16'd1;
-    u_SystolicArray.IB[1] = 16'd2;
+    u_SystolicArray.IB[0] = 16'd0;
+    u_SystolicArray.IB[1] = 16'd0;
     u_SystolicArray.IB[2] = 16'd11;
     u_SystolicArray.IB[3] = 16'd10;
     u_SystolicArray.OB[0] = 16'd17;
     u_SystolicArray.OB[1] = 16'd16;
     u_SystolicArray.OB[2] = 16'd15;
     u_SystolicArray.OB[3] = 16'd9;
-    u_SystolicArray.size = 4'd8;
-    u_SystolicArray.size_next = 4'd8;
+    u_SystolicArray.size = 4'd6;
+    u_SystolicArray.size_next = 4'd6;
 
     @(posedge i_CLK);
 
-    ref_queue.push_back(16'd1);
-    ref_queue.push_back(16'd2);
     ref_queue.push_back(16'd11);
     ref_queue.push_back(16'd10);
     ref_queue.push_back(16'd17);
     ref_queue.push_back(16'd16);
     ref_queue.push_back(16'd15);
     ref_queue.push_back(16'd9);
-
-    ref_size = 8;
+    ref_size = 6;
     for (int i = 0; i < ref_size; i++) begin
       for (int j = i + 1; j < ref_size; j++) begin
         if (ref_queue[i] < ref_queue[j]) begin
@@ -206,64 +135,8 @@ module systolic_array_tb;
     end
     repeat (10) @(posedge i_CLK);
 
-    for (int i = 0; i < 8; i++) begin
+    for (int i = 0; i < QUEUE_SIZE; i++) begin
       dequeue();
-      if (o_read_ready) begin
-        assert (o_data == ref_queue[0])
-        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
-      end else begin
-        assert (o_data == '0)
-        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
-      end
-    end
-
-    // Test Case 4: Successive increasing numbers in OB to IB+1
-    $display("\nTest Case 4: Successive decreasing numbers from OB to IB+1");
-    ref_queue.delete();
-    
-    u_SystolicArray.IB[0] = 16'd1;
-    u_SystolicArray.IB[1] = 16'd2;
-    u_SystolicArray.IB[2] = 16'd7;
-    u_SystolicArray.IB[3] = 16'd13;
-    u_SystolicArray.OB[0] = 16'd17;
-    u_SystolicArray.OB[1] = 16'd16;
-    u_SystolicArray.OB[2] = 16'd10;
-    u_SystolicArray.OB[3] = 16'd11;
-    u_SystolicArray.size = 4'd8;
-    u_SystolicArray.size_next = 4'd8;
-
-    @(posedge i_CLK);
-
-    ref_queue.push_back(16'd1);
-    ref_queue.push_back(16'd2);
-    ref_queue.push_back(16'd7);
-    ref_queue.push_back(16'd13);
-    ref_queue.push_back(16'd17);
-    ref_queue.push_back(16'd16);
-    ref_queue.push_back(16'd10);
-    ref_queue.push_back(16'd11);
-
-    ref_size = 8;
-    for (int i = 0; i < ref_size; i++) begin
-      for (int j = i + 1; j < ref_size; j++) begin
-        if (ref_queue[i] < ref_queue[j]) begin
-          tmp = ref_queue[i];
-          ref_queue[i] = ref_queue[j];
-          ref_queue[j] = tmp;
-        end
-      end
-    end
-    repeat (10) @(posedge i_CLK);
-
-    for (int i = 0; i < 8; i++) begin
-      dequeue();
-      if (o_read_ready) begin
-        assert (o_data == ref_queue[0])
-        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
-      end else begin
-        assert (o_data == '0)
-        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
-      end
     end
 
     if (error_count == 0) begin
@@ -279,6 +152,9 @@ module systolic_array_tb;
   task automatic dequeue();
     begin
       if (o_read_ready) begin
+        assert (o_data == ref_queue[0])
+        else
+          begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
         i_wrt  = 0;
         i_read = 1;
         for (int i = 0; i < ref_size - 1; i++) begin
@@ -288,41 +164,10 @@ module systolic_array_tb;
         ref_size--;
         
       end else begin
-        $display("Dequeue: Queue empty, skipping dequeue");
+        i_wrt  = 0;
+        i_read = 0;
       end
       @(posedge i_CLK);
-      i_wrt  = 0;
-      i_read = 0;
-      repeat (3) @(posedge i_CLK);
-    end
-  endtask
-
-  // Task to replace root node
-  task automatic replace(input logic [DATA_WIDTH-1:0] value);
-    logic [DATA_WIDTH-1:0] tmp;
-    begin
-      if (ref_size > 0) begin
-        i_wrt  = 1;
-        i_read = 1;
-        i_data = value;
-        ref_queue[0] = value;
-        for (int i = 0; i < ref_size; i++) begin
-          for (int j = i + 1; j < ref_size; j++) begin
-            if (ref_queue[i] < ref_queue[j]) begin
-              tmp = ref_queue[i];
-              ref_queue[i] = ref_queue[j];
-              ref_queue[j] = tmp;
-            end
-          end
-        end
-      end else begin
-        $display("Replace: Queue empty, skipping replace");
-      end
-      
-      @(posedge i_CLK);
-      i_wrt  = 0;
-      i_read = 0;
-      repeat (2) @(posedge i_CLK); 
     end
   endtask
 

--- a/hwpq/systolic_array/rtl/sim/systolic_array_bug_tb.sv
+++ b/hwpq/systolic_array/rtl/sim/systolic_array_bug_tb.sv
@@ -68,6 +68,14 @@ module systolic_array_tb;
     // Test Case 1: Successive decreasing numbers in IB
     $display("\nTest Case 1: Successive decreasing numbers in IB");
     ref_queue.delete();
+
+    /* Icarus Verilog (12.0) cannot force an unpacked array, so the DUT buffers are seeded
+      one element at a time with plain hierarchical assignments instead of
+        `force u_SystolicArray.IB = '{16'd1, 16'd6, 16'd4, 16'd2};`
+      which fails with "Assignment to an entire array or to an array slice is not yet supported".
+      Forcing a single word fails too with "cannot force to the word of a variable array". 
+      The same applies to the other test cases below. */
+    
     u_SystolicArray.IB[0] = 16'd1;
     u_SystolicArray.IB[1] = 16'd6;
     u_SystolicArray.IB[2] = 16'd4;

--- a/hwpq/systolic_array/rtl/sim/systolic_array_bug_tb.sv
+++ b/hwpq/systolic_array/rtl/sim/systolic_array_bug_tb.sv
@@ -13,8 +13,8 @@ module systolic_array_tb;
   logic [DATA_WIDTH-1:0] i_data;
 
   // Output signals
-  logic                  o_full;
-  logic                  o_empty;
+  logic                  o_write_ready;
+  logic                  o_read_ready;
   logic [DATA_WIDTH-1:0] o_data;
 
   // Reference array for verification
@@ -42,8 +42,8 @@ module systolic_array_tb;
       .i_wrt(i_wrt),
       .i_read(i_read),
       .i_data(i_data),
-      .o_full(o_full),
-      .o_empty(o_empty),
+      .o_write_ready(o_write_ready),
+      .o_read_ready(o_read_ready),
       .o_data(o_data)
   );
 
@@ -111,7 +111,7 @@ module systolic_array_tb;
 
     for (int i = 0; i < 8; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue[0])
         else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
@@ -160,7 +160,7 @@ module systolic_array_tb;
 
     for (int i = 0; i < 8; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue[0])
         else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
@@ -208,7 +208,7 @@ module systolic_array_tb;
 
     for (int i = 0; i < 8; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue[0])
         else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
@@ -257,7 +257,7 @@ module systolic_array_tb;
 
     for (int i = 0; i < 8; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue[0])
         else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
@@ -278,7 +278,7 @@ module systolic_array_tb;
   // Task to read root node
   task automatic dequeue();
     begin
-      if (!o_empty) begin
+      if (o_read_ready) begin
         i_wrt  = 0;
         i_read = 1;
         for (int i = 0; i < ref_size - 1; i++) begin

--- a/hwpq/systolic_array/rtl/sim/systolic_array_tb.sv
+++ b/hwpq/systolic_array/rtl/sim/systolic_array_tb.sv
@@ -2,7 +2,7 @@
 
 module systolic_array_tb;
   // Parameters matching the module under test
-  parameter int QUEUE_SIZE = 8;
+  parameter int QUEUE_SIZE = 16;
   parameter int DATA_WIDTH = 16;
 
   // Clock and reset signals
@@ -27,9 +27,9 @@ module systolic_array_tb;
   logic [DATA_WIDTH-1:0] random_value;
 
   typedef enum int {
-    ENQUEUE = 1,
-    DEQUEUE = 2,
-    REPLACE = 3
+    ENQUEUE = 0,
+    DEQUEUE = 1,
+    REPLACE = 2
   } t_operation;
   t_operation random_operation;
 
@@ -68,78 +68,51 @@ module systolic_array_tb;
 
     // Initialize the queue, fill it up to QUEUE_SIZE with random values
     for (int i = 0; i < QUEUE_SIZE; i++) begin
-      random_value = $urandom_range(0, 1024);
+      random_value = $urandom_range(1, 1024);
       enqueue(random_value);
-      repeat (5) @(posedge i_CLK);  // to make sure that the queue is correctly initialized
     end
-    repeat (5) @(posedge i_CLK);  // wait for the queue to stabilize
 
     // Test Case 1: Dequeue nodes
     // Dequeue nodes for QUEUE_SIZE times
     $display("\nTest Case 1: Dequeue Test");
     for (int i = 0; i < QUEUE_SIZE; i++) begin
       dequeue();
-      if (o_read_ready) begin
-        assert (o_data == ref_queue[0])
-        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
-      end else begin
-        assert (o_data == '0)
-        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
-      end
     end
 
     // Test Case 2: Enqueue nodes
     // Enqueue random values for QUEUE_SIZE times
     $display("\nTest Case 2: Enqueue Test");
     for (int i = 0; i < QUEUE_SIZE; i++) begin
-      random_value = $urandom_range(0, 1024);
+      random_value = $urandom_range(1, 1024);
       enqueue(random_value);
-      assert (o_data == ref_queue[0])
-      else begin error_count++; $error("Enqueue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
     end
 
     // Test Case 3: Replace nodes
     // Replace root node for QUEUE_SIZE times
     $display("\nTest Case 3: Replace Test");
     for (int i = 0; i < QUEUE_SIZE; i++) begin
-      random_value = $urandom_range(0, 1024);
+      random_value = $urandom_range(1, 1024);
       replace(random_value);
-      assert (o_data == ref_queue[0])
-      else begin error_count++; $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
     end
 
     // Test Case 4: Stress Test
     // stress test, mix operations
 
     $display("\nTest Case 4: Stress Test");
-    for (int i = 0; i < 100; i++) begin
-      random_value = $urandom_range(0, 1024);
-      random_operation = t_operation'($urandom_range(1, 3));  
+    for (int i = 0; i < 1000; i++) begin
+      random_value = $urandom_range(1, 1024);
+      random_operation = t_operation'($urandom_range(0, 2));  
       case (random_operation)
         ENQUEUE: begin
           enqueue(random_value);
-          assert (o_data == ref_queue[0])
-          else
-            begin error_count++; $error("Enqueue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
         end
 
         DEQUEUE: begin
           dequeue();
-          if (o_read_ready) begin
-            assert (o_data == ref_queue[0])
-            else
-              begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
-          end else begin
-            assert (o_data == '0)
-            else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
-          end
         end
 
         REPLACE: begin
           replace(random_value);
-          assert (o_data == ref_queue[0])
-          else
-            begin error_count++; $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
         end
 
         default: begin
@@ -179,12 +152,10 @@ module systolic_array_tb;
           end
         end
       end else begin
-        $display("Enqueue: Queue full, skipping enqueue");
+        i_wrt  = 0;
+        i_read = 0;
       end
       @(posedge i_CLK);
-      i_wrt  = 0;
-      i_read = 0;
-      repeat (2) @(posedge i_CLK); 
     end
   endtask
 
@@ -192,6 +163,9 @@ module systolic_array_tb;
   task automatic dequeue();
     begin
       if (o_read_ready) begin
+        assert (o_data == ref_queue[0])
+        else
+          begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
         i_wrt  = 0;
         i_read = 1;
         for (int i = 0; i < ref_size - 1; i++) begin
@@ -201,12 +175,10 @@ module systolic_array_tb;
         ref_size--;
         
       end else begin
-        $display("Dequeue: Queue empty, skipping dequeue");
+        i_wrt  = 0;
+        i_read = 0;
       end
       @(posedge i_CLK);
-      i_wrt  = 0;
-      i_read = 0;
-      repeat (3) @(posedge i_CLK);
     end
   endtask
 
@@ -214,7 +186,10 @@ module systolic_array_tb;
   task automatic replace(input logic [DATA_WIDTH-1:0] value);
     logic [DATA_WIDTH-1:0] tmp;
     begin
-      if (ref_size > 0) begin
+      if (o_read_ready) begin
+        assert (o_data == ref_queue[0])
+        else
+          begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
         i_wrt  = 1;
         i_read = 1;
         i_data = value;
@@ -229,13 +204,10 @@ module systolic_array_tb;
           end
         end
       end else begin
-        $display("Replace: Queue empty, skipping replace");
+        i_wrt  = 0;
+        i_read = 0;
       end
-      
       @(posedge i_CLK);
-      i_wrt  = 0;
-      i_read = 0;
-      repeat (2) @(posedge i_CLK); 
     end
   endtask
 

--- a/hwpq/systolic_array/rtl/sim/systolic_array_tb.sv
+++ b/hwpq/systolic_array/rtl/sim/systolic_array_tb.sv
@@ -51,6 +51,8 @@ module systolic_array_tb;
   // Clock generation: 10ns period
   always #5 CLK <= ~CLK;
 
+  int error_count = 0;
+
   initial begin
     // Initialize signals
     CLK = 0;
@@ -79,10 +81,10 @@ module systolic_array_tb;
       dequeue();
       if (!o_empty) begin
         assert (o_data == ref_queue[0])
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
         assert (o_data == '0)
-        else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+        else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
       end
     end
 
@@ -93,7 +95,7 @@ module systolic_array_tb;
       random_value = $urandom_range(0, 1024);
       enqueue(random_value);
       assert (o_data == ref_queue[0])
-      else $error("Enqueue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+      else begin error_count++; $error("Enqueue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
     end
 
     // Test Case 3: Replace nodes
@@ -103,7 +105,7 @@ module systolic_array_tb;
       random_value = $urandom_range(0, 1024);
       replace(random_value);
       assert (o_data == ref_queue[0])
-      else $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+      else begin error_count++; $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
     end
 
     // Test Case 4: Stress Test
@@ -112,13 +114,13 @@ module systolic_array_tb;
     $display("\nTest Case 4: Stress Test");
     for (int i = 0; i < 100; i++) begin
       random_value = $urandom_range(0, 1024);
-      random_operation = t_operation'($urandom_range(1,3));
+      random_operation = t_operation'($urandom_range(1, 3));  
       case (random_operation)
         ENQUEUE: begin
           enqueue(random_value);
           assert (o_data == ref_queue[0])
           else
-            $error("Enqueue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+            begin error_count++; $error("Enqueue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
         end
 
         DEQUEUE: begin
@@ -126,10 +128,10 @@ module systolic_array_tb;
           if (!o_empty) begin
             assert (o_data == ref_queue[0])
             else
-              $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+              begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
           end else begin
             assert (o_data == '0)
-            else $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data);
+            else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", '0, o_data); end;
           end
         end
 
@@ -137,7 +139,7 @@ module systolic_array_tb;
           replace(random_value);
           assert (o_data == ref_queue[0])
           else
-            $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data);
+            begin error_count++; $error("Replace: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
         end
 
         default: begin
@@ -146,8 +148,13 @@ module systolic_array_tb;
       endcase
     end
 
-    $display("\nTest completed! ");
-    $finish;
+    if (error_count == 0) begin
+      $display("\nTest completed!");
+      $finish;
+    end else begin
+      $display("\n%0d error(s) detected during simulation.", error_count);
+      $fatal(1, "Test FAILED with %0d error(s).", error_count);
+    end
   end
 
   // Task to write to the end of the queue

--- a/hwpq/systolic_array/rtl/sim/systolic_array_tb.sv
+++ b/hwpq/systolic_array/rtl/sim/systolic_array_tb.sv
@@ -15,8 +15,8 @@ module systolic_array_tb;
   logic [DATA_WIDTH-1:0] i_data;
 
   // Output signals
-  logic                  o_full;
-  logic                  o_empty;
+  logic                  o_write_ready;
+  logic                  o_read_ready;
   logic [DATA_WIDTH-1:0] o_data;
 
   // Reference array for verification
@@ -43,8 +43,8 @@ module systolic_array_tb;
       .i_wrt(i_wrt),
       .i_read(i_read),
       .i_data(i_data),
-      .o_full(o_full),
-      .o_empty(o_empty),
+      .o_write_ready(o_write_ready),
+      .o_read_ready(o_read_ready),
       .o_data(o_data)
   );
 
@@ -79,7 +79,7 @@ module systolic_array_tb;
     $display("\nTest Case 1: Dequeue Test");
     for (int i = 0; i < QUEUE_SIZE; i++) begin
       dequeue();
-      if (!o_empty) begin
+      if (o_read_ready) begin
         assert (o_data == ref_queue[0])
         else begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
       end else begin
@@ -125,7 +125,7 @@ module systolic_array_tb;
 
         DEQUEUE: begin
           dequeue();
-          if (!o_empty) begin
+          if (o_read_ready) begin
             assert (o_data == ref_queue[0])
             else
               begin error_count++; $error("Dequeue: Node f value mismatch -> expected %d, got %d", ref_queue[0], o_data); end;
@@ -161,7 +161,7 @@ module systolic_array_tb;
   task automatic enqueue(input logic [DATA_WIDTH-1:0] value);
     logic [DATA_WIDTH-1:0] tmp;
     begin
-      if (!o_full) begin
+      if (o_write_ready) begin
         i_wrt  = 1;
         i_read = 0;
         i_data = value;
@@ -191,7 +191,7 @@ module systolic_array_tb;
   // Task to read root node
   task automatic dequeue();
     begin
-      if (!o_empty) begin
+      if (o_read_ready) begin
         i_wrt  = 0;
         i_read = 1;
         for (int i = 0; i < ref_size - 1; i++) begin

--- a/hwpq/systolic_array/rtl/sim/systolic_array_tb.sv
+++ b/hwpq/systolic_array/rtl/sim/systolic_array_tb.sv
@@ -6,8 +6,8 @@ module systolic_array_tb;
   parameter int DATA_WIDTH = 16;
 
   // Clock and reset signals
-  logic                  CLK;
-  logic                  RSTn;
+  logic                  i_CLK;
+  logic                  i_RSTn;
 
   // Input signals
   logic                  i_wrt;
@@ -38,8 +38,8 @@ module systolic_array_tb;
       .QUEUE_SIZE(QUEUE_SIZE),
       .DATA_WIDTH(DATA_WIDTH)
   ) u_SystolicArray (
-      .i_CLK(CLK),
-      .i_RSTn(RSTn),
+      .i_CLK(i_CLK),
+      .i_RSTn(i_RSTn),
       .i_wrt(i_wrt),
       .i_read(i_read),
       .i_data(i_data),
@@ -49,30 +49,30 @@ module systolic_array_tb;
   );
 
   // Clock generation: 10ns period
-  always #5 CLK <= ~CLK;
+  always #5 i_CLK <= ~i_CLK;
 
   int error_count = 0;
 
   initial begin
     // Initialize signals
-    CLK = 0;
-    RSTn = 0;
+    i_CLK = 0;
+    i_RSTn = 0;
     i_wrt = 0;
     i_read = 0;
     i_data = 0;
 
     // Reset the module
-    @(posedge CLK);
-    RSTn = 1;
-    @(posedge CLK);
+    @(posedge i_CLK);
+    i_RSTn = 1;
+    @(posedge i_CLK);
 
     // Initialize the queue, fill it up to QUEUE_SIZE with random values
     for (int i = 0; i < QUEUE_SIZE; i++) begin
       random_value = $urandom_range(0, 1024);
       enqueue(random_value);
-      repeat (5) @(posedge CLK);  // to make sure that the queue is correctly initialized
+      repeat (5) @(posedge i_CLK);  // to make sure that the queue is correctly initialized
     end
-    repeat (5) @(posedge CLK);  // wait for the queue to stabilize
+    repeat (5) @(posedge i_CLK);  // wait for the queue to stabilize
 
     // Test Case 1: Dequeue nodes
     // Dequeue nodes for QUEUE_SIZE times
@@ -181,10 +181,10 @@ module systolic_array_tb;
       end else begin
         $display("Enqueue: Queue full, skipping enqueue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (2) @(posedge CLK); 
+      repeat (2) @(posedge i_CLK); 
     end
   endtask
 
@@ -203,10 +203,10 @@ module systolic_array_tb;
       end else begin
         $display("Dequeue: Queue empty, skipping dequeue");
       end
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (3) @(posedge CLK);
+      repeat (3) @(posedge i_CLK);
     end
   endtask
 
@@ -232,10 +232,10 @@ module systolic_array_tb;
         $display("Replace: Queue empty, skipping replace");
       end
       
-      @(posedge CLK);
+      @(posedge i_CLK);
       i_wrt  = 0;
       i_read = 0;
-      repeat (2) @(posedge CLK); 
+      repeat (2) @(posedge i_CLK); 
     end
   endtask
 

--- a/hwpq/systolic_array/rtl/src/systolic_array.sv
+++ b/hwpq/systolic_array/rtl/src/systolic_array.sv
@@ -1,5 +1,26 @@
 `default_nettype none
 
+/*******************************************************************************
+  Module Name: systolic_array
+  Date: 2026/06/18
+  Description: A priority queue implementation using a systolic array of an
+               input buffer (IB) and output buffer (OB). New nodes shift
+               through the IB, swapping bubble-sort style with adjacent OB
+               nodes so higher-priority (larger f) values migrate into the
+               OB; dequeuing the OB head propagates a "bubble" back through
+               the array to refill it.
+  Parameters: QUEUE_SIZE - Maximum number of elements in the priority queue
+              DATA_WIDTH - Bit width of the node's evaluation value (f)
+  Inputs: i_CLK - System clock
+          i_RSTn - Active-low reset signal
+          i_wrt - Enqueue signal
+          i_read - Dequeue signal
+          i_data - Node data input
+  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
+           o_empty - High when the queue is empty
+           o_data - Node data output (highest priority element)
+*******************************************************************************/
+
 module systolic_array #(
     parameter int QUEUE_SIZE = 4,  // Size of the buffers (number of positions)
     parameter int DATA_WIDTH = 16  // Width of the node data (evaluation function value 'f')

--- a/hwpq/systolic_array/rtl/src/systolic_array.sv
+++ b/hwpq/systolic_array/rtl/src/systolic_array.sv
@@ -6,9 +6,11 @@
   Description: A priority queue implementation using a systolic array of an
                input buffer (IB) and output buffer (OB). New nodes shift
                through the IB, swapping bubble-sort style with adjacent OB
-               nodes so higher-priority (larger f) values migrate into the
+               nodes so higher-priority values migrate into the
                OB; dequeuing the OB head propagates a "bubble" back through
-               the array to refill it.
+               the array to refill it. The module reserves MIN_VALUE to
+               represent an invalid entry, which is reflected in the test
+               benches avoiding writing 0.
   Parameters: QUEUE_SIZE - Maximum number of elements in the priority queue
               DATA_WIDTH - Bit width of the node's evaluation value (f)
   Inputs: i_CLK - System clock
@@ -21,8 +23,12 @@
            o_data - Node data output (highest priority element)
 *******************************************************************************/
 
+`default_nettype none
+
+// this module cannot use the MIN_VALUE, we treat the MIN_VALUE as an invalid
+
 module systolic_array #(
-    parameter int QUEUE_SIZE = 4,  // Size of the buffers (number of positions)
+    parameter int QUEUE_SIZE = 128,  // Size of the buffers (number of positions)
     parameter int DATA_WIDTH = 16  // Width of the node data (evaluation function value 'f')
 ) (
     input var logic                   i_CLK,
@@ -34,9 +40,10 @@ module systolic_array #(
     input var logic [DATA_WIDTH-1:0]  i_data,  // Node data input
 
     // Output
-    output var logic                  o_write_ready,   // High if the queue can accept a write
-    output var logic                  o_read_ready,  // High if the queue has data to read
-    output var logic [DATA_WIDTH-1:0] o_data    // Node data output
+    output var logic [DATA_WIDTH-1:0] o_data,    // Node data output
+    output var logic                  o_write_ready, // High if systolic is full
+    output var logic                  o_read_ready
+
 );
 
   // Constant
@@ -53,17 +60,26 @@ module systolic_array #(
   logic                    IB_greater_than_OB_next[HALF_SIZE-1];
   logic                    OB_next_greater_than_OB[HALF_SIZE-1];
 
+  logic                    IB_shift               [HALF_SIZE-1];
+  logic                    IB_shift_valid               [HALF_SIZE-1];
+
+  logic                    OB_shift               [HALF_SIZE-1];
+  logic                    OB_shift_valid         [HALF_SIZE-1];
+
+  logic                    IB_shift_to_OB         [HALF_SIZE-1];
+
   // Control signals
   int                      size;
   int                      size_next;
   logic                    full;
   logic                    empty;
 
-  assign full  = (size >= QUEUE_SIZE);
+  assign full  = (size >= QUEUE_SIZE - 2);
   assign empty = (size <= 0);
-  assign o_write_ready  = !full;
-  assign o_read_ready = !empty;
   assign o_data  = OB[0];
+  // we need 2 empty spaces for the systolic to work, and we cannot write/read right after a read
+  assign o_write_ready = !(size >= (QUEUE_SIZE - 3)) && (o_data != MIN_VALUE || empty); 
+  assign o_read_ready = !empty && (o_data != MIN_VALUE);
 
   // Sequential logic
   always_ff @(posedge i_CLK or negedge i_RSTn) begin
@@ -82,15 +98,17 @@ module systolic_array #(
 
       // Enqueue operation
       if (i_wrt && !i_read && !full) begin
-        IB[0] <= i_data;  // insert the new node at the head of IB
+        if (i_data > OB[0]) begin
+          OB[0] <= i_data;
+          IB[0] <= OB[0];
+        end else begin
+          IB[0] <= i_data;  // insert the new node at the head of IB
+        end
       end
 
       // Replace operation
       if (i_wrt && i_read) begin
-        if (full) begin
-          OB[0] <= IB[0];   // replace OB with the head of IB
-          IB[0] <= i_data;  // replace the head of IB
-        end else if (empty) begin
+        if (empty) begin
           OB[0] <= i_data;  // insert the new node at the head of OB
         end else begin
           IB[0] <= i_data;  // replace the head of IB
@@ -104,28 +122,75 @@ module systolic_array #(
       // Sorting logic
       for (int i = 0; i < HALF_SIZE; i++) begin  // Iterate through each element
         priority case (1'b1)
-          IB_greater_than_OB[i]: begin
-            IB[i] <= OB[i];
-            OB[i] <= IB[i];
+          OB_shift[i] && OB_shift_valid[i]: begin
+            OB[i] <= OB[i+1]; 
+            if ((i == (HALF_SIZE - 2) || !OB_shift_valid[i+1] || !IB_shift_to_OB[i+1] || !OB_shift[i+1] || (OB[i+2] == 0))) OB[i+1] <= MIN_VALUE;
           end
+          default: begin
+            // No action needed
+          end
+        endcase
 
-          OB_next_greater_than_OB[i] && (!(OB_next_greater_than_OB[i+1]) || i == HALF_SIZE - 2) && (!(IB_greater_than_OB[i+1])): begin  // OB[i+1] > OB[i]
-            // Swap OB[i] and OB[i+1]
+        priority case (1'b1)
+          IB_shift[i] && IB_shift_valid[i]: begin
+            // We slide this value down
+            IB[i+1] <= IB[i];
+            if ((i == 0 && !i_wrt) || (i > 0 && !IB_shift_valid[i-1])) IB[i] <= MIN_VALUE;
+          end
+          default: begin
+            // No action needed
+          end
+        endcase
+
+        priority case (1'b1)
+          OB_next_greater_than_OB[i] && !OB_shift_valid[i] && !IB_greater_than_OB[i]
+          && (i > 0 && !IB_greater_than_OB_next[i-1]): begin
+            // If we cannot shift, we can swap
             OB[i+1] <= OB[i];
-            OB[i]   <= OB[i+1];
+            OB[i] <= OB[i+1];
           end
 
-          IB_greater_than_OB_next[i] && (IB[i+1] == MIN_VALUE): begin
+          IB_shift_to_OB[i]: begin
+            // if OB is shifting while we want to swap in, we can just swap down instead
+            OB[i] <= IB[i];
+            if (!(IB_shift[i-1] && IB_shift_valid[i-1])) IB[i] <= MIN_VALUE;
+          end
+
+          IB_greater_than_OB[i] && !(i < (HALF_SIZE-1) && OB_shift[i] && OB_shift_valid[i]): begin
+            IB[i] <=  OB[i];
+            OB[i] <=  IB[i];
+          end
+
+          IB_greater_than_OB_next[i] && (!IB_greater_than_OB[i+1])
+          && ((IB[i+1] == 0) || (IB_greater_than_OB_next[i+1]) || (IB_shift[i+1])) && IB_shift_valid[i]: begin
             // Move IB[i] to OB[i+1], and move OB[i+1] to IB[i+1]
             OB[i+1] <= IB[i];
             IB[i+1] <= OB[i+1];
-            IB[i]   <= MIN_VALUE;
+            // if we are also writing this cycle, we need to replace the value with i_data or OB[0] is i_data > OB[0]
+            if (i == 0 && i_wrt) begin
+              if (i_data > OB[0] && !i_read) begin
+                IB[i] <= OB[0];
+              end else begin
+                IB[i] <= i_data;
+              end
+            end
+            if ((i > 0 && (IB_shift_to_OB[i-1] || IB_greater_than_OB[i-1])) || (i == 0 && !i_wrt)) begin
+              IB[i] <= MIN_VALUE;
+            end
           end
 
-          IB_greater_than_IB_next[i] && (!(IB_greater_than_IB_next[i+1]) || i == HALF_SIZE - 2) && (!(IB_greater_than_OB[i+1])): begin  // IB[i] > IB[i+1]
-            // Swap IB[i] and IB[i+1]
+          IB_greater_than_OB_next[i] && !IB_shift_valid[i] && !IB_greater_than_OB[i+1]: begin
+            // If we cannot shift, we can swap
+            IB[i] <= OB[i+1];
+            OB[i+1] <= IB[i];
+          end
+
+          IB_greater_than_IB_next[i] && !IB_shift_valid[i]
+          && ((i == (HALF_SIZE - 2)) || (!IB_greater_than_IB_next[i+1] && !IB_greater_than_OB_next[i+1]))
+          && (!IB_greater_than_OB[i+1]): begin
+            // If we cannot shift, we can swap
+            IB[i] <= IB[i+1];
             IB[i+1] <= IB[i];
-            IB[i]   <= IB[i+1];
           end
 
           default: begin
@@ -138,14 +203,38 @@ module systolic_array #(
 
   // Combinational logic
   always_comb begin
-    // comparsion results
-    for (int i = 0; i < QUEUE_SIZE; i++) begin
-      IB_greater_than_OB[i] = IB[i] > OB[i];
+
+    for (int i=0; i<HALF_SIZE-1;i++) begin
+      OB_shift[i] = (OB[i+1] >= IB[i]) && (OB[i+1] >= IB[i+1]) && (OB[i+1] != MIN_VALUE);
+    end 
+    OB_shift_valid[0] = OB[0] == 0;
+    for (int i=1; i<HALF_SIZE-1;i++) begin
+      OB_shift_valid[i] = (OB[i-1] == 0 || OB_shift_valid[i-1]) && OB_shift[i-1];
     end
-    for (int i = 0; i < QUEUE_SIZE - 1; i++) begin
+
+
+    // comparsion results
+    for (int i = 0; i < HALF_SIZE; i++) begin
+      // IB_greater_than_OB should not happen at the front of the array
+      IB_greater_than_OB[i] = (IB[i] > OB[i]);
+    end
+    for (int i = 0; i < HALF_SIZE - 1; i++) begin
       IB_greater_than_OB_next[i] = IB[i] > OB[i+1];
       IB_greater_than_IB_next[i] = IB[i] > IB[i+1];
       OB_next_greater_than_OB[i] = OB[i+1] > OB[i];
+      IB_shift_to_OB[i] = IB_greater_than_OB_next[i] && (i > 0 && OB_shift[i-1] && OB_shift_valid[i-1]);
+    end
+
+    for (int i=HALF_SIZE-2; i >= 0; i--) begin
+      IB_shift[i] = (i < (HALF_SIZE-2) && (IB_greater_than_OB_next[i+1] || IB_greater_than_IB_next[i+1])) || ((IB[i] <= OB[i]) && (IB[i] <= OB[i+1])) || ((OB[i] == 0) && (i == 0) && (IB[i] <= OB[i+1]));
+    end
+    
+    // maybe it should be if it is equal to min_value
+    IB_shift_valid[HALF_SIZE-2] = IB[HALF_SIZE-1] == MIN_VALUE;
+    for (int i=HALF_SIZE-3; i >= 0; i--) begin
+      // we can do shifts if at some point the value ahead of us is 0, otherwise we must swap as there is no room for shifts
+      IB_shift_valid[i] = (IB[i+1] == 0 || IB_shift_valid[i+1] || IB_shift_to_OB[i+1]) && !IB_shift_to_OB[i] 
+      && !((IB_greater_than_OB[i+1] || IB_greater_than_OB[i]) && !(i < (HALF_SIZE-1) && OB_shift[i] && OB_shift_valid[i]));
     end
 
     // compute size_next

--- a/hwpq/systolic_array/rtl/src/systolic_array.sv
+++ b/hwpq/systolic_array/rtl/src/systolic_array.sv
@@ -16,8 +16,8 @@
           i_wrt - Enqueue signal
           i_read - Dequeue signal
           i_data - Node data input
-  Outputs: o_full - High when the queue is at maximum capacity (QUEUE_SIZE)
-           o_empty - High when the queue is empty
+  Outputs: o_write_ready - High when the queue has room to accept a write
+           o_read_ready - High when the queue holds data available to read
            o_data - Node data output (highest priority element)
 *******************************************************************************/
 
@@ -34,8 +34,8 @@ module systolic_array #(
     input var logic [DATA_WIDTH-1:0]  i_data,  // Node data input
 
     // Output
-    output var logic                  o_full,   // Queue is full
-    output var logic                  o_empty,  // Queue is empty
+    output var logic                  o_write_ready,   // High if the queue can accept a write
+    output var logic                  o_read_ready,  // High if the queue has data to read
     output var logic [DATA_WIDTH-1:0] o_data    // Node data output
 );
 
@@ -61,8 +61,8 @@ module systolic_array #(
 
   assign full  = (size >= QUEUE_SIZE);
   assign empty = (size <= 0);
-  assign o_full  = full;
-  assign o_empty = empty;
+  assign o_write_ready  = !full;
+  assign o_read_ready = !empty;
   assign o_data  = OB[0];
 
   // Sequential logic

--- a/scripts/run_sim.sh
+++ b/scripts/run_sim.sh
@@ -7,7 +7,7 @@
 #   <testbench_file>  path to the testbench .sv (e.g. hwpq/register_tree/rtl/sim/register_tree_tb.sv)
 #   <top_module>      top-level module name declared in the testbench (e.g. register_tree_tb)
 #
-set -euo pipefail
+set -eu
 
 MODULE="$1"
 TB="$2"
@@ -37,13 +37,12 @@ iverilog -g2012 -Wall -s "${TOP}" -o "${BUILD}/sim.vvp" "${PKGS[@]}" "${REST[@]}
 
 echo "==> Running ${MODULE}"
 vvp "${BUILD}/sim.vvp" | tee "${LOG}"
+status="${PIPESTATUS[0]}"
 
 echo "==> Checking results for ${MODULE}"
-status=0
 
-if grep -inE 'error|mismatch|assertion|\bfail' "${LOG}"; then
-  echo "::error::${MODULE}: assertion/error output detected in simulation log"
-  status=1
+if [ "${status}" -ne 0 ]; then
+  echo "::error::${MODULE}: testbench exited with status ${status}"
 fi
 
 if ! grep -qiE 'test[[:space:]]+completed' "${LOG}"; then


### PR DESCRIPTION
Turns the queue modules' occupancy-only flags into a real ready/busy handshake. Each module now folds a !busy term into those two outputs, so a master (and the testbenches) can poll for quiescence instead of guessing.

The rule is "busy = my correctness invariant isn't satisfied yet," expressed with logic each module already has:
- register_array : never busy (sort network folds op in the same cycle, II=1)
- register_array_pipelined : pipeline can_accept / head_valid
- register_tree/_pipelined : worst-case settle counter (settle_cnt), O(N) heap-invariant variant left  commented for reference                   
- systolic_array : head-sentinel (o_data != MIN_VALUE)
- bram_tree : FSM idle_and_no_new_request (state==IDLE)
- bram_tree_pipelined  : pipeline sift_done / root_done

The command decode and size counter are gated on !busy, so the module now refuses commands it can't accept.

**Merged**: @johnsony0 /iverilog_testing

Folds in Johnson's work on the two modules:
- systolic_array : sort redesign that keeps OB in order (fixes the back-to-back-command data-loss bug), reserving 2 sentinel slots. Measured 1-cyc enqueue / 2-cyc dequeue.
- bram_tree : FSM rewrite exposing the IDLE-based handshake above (supersedes an earlier minimal IDLE-wiring commit).

**Testbenches**

Converted from fixed settle waits to negedge ready-polling (drive + poll on the negedge to avoid the clock-edge race). All static latency constants removed from the converted TBs. All 8 simulations pass.